### PR TITLE
Add processor type to pubsub.Message attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         cache: true
     - run: make lint
     - run: make fmt
-    - uses: dominikh/staticcheck-action@v1.2.0
+    - uses: dominikh/staticcheck-action@v1.3.0
       with:
-        version: "2022.1.1"
+        version: "2022.1.3"
         install-go: false
     - name: Verify repo is up-to-date
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
         cache: true
     - run: make lint
     - run: make fmt
-    - uses: dominikh/staticcheck-action@v1.3.0
-      with:
-        version: "2022.1.3"
-        install-go: false
     - name: Verify repo is up-to-date
       run: |
         if [ -n "$(git status --porcelain)" ]; then

--- a/kafka/doc.go
+++ b/kafka/doc.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // Package kafka abstracts the production and consumption of model.Batch
 // to and from Kafka.
 package kafka

--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -26,10 +26,11 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsublite/pscompat"
-	"github.com/elastic/apm-data/model"
-	"github.com/elastic/apm-queue/queuecontext"
 	"go.uber.org/zap"
 	"google.golang.org/api/option"
+
+	"github.com/elastic/apm-data/model"
+	"github.com/elastic/apm-queue/queuecontext"
 )
 
 // ConsumerConfig defines the configuration for the Kafka consumer.

--- a/pubsublite/doc.go
+++ b/pubsublite/doc.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // Package pubsublite abstracts the production and consumption of model.Batch
 // to and from GCP PubSub Lite.
 package pubsublite

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -111,7 +111,6 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 	if !ok {
 		return errors.New("project ID missing")
 	}
-	attributes := map[string]string{"project_id": projectID}
 	var responses []*pubsub.PublishResult
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -126,7 +125,11 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 			return err
 		}
 		responses = append(responses, p.producer.Publish(ctx, &pubsub.Message{
-			Attributes: attributes, Data: encoded,
+			Attributes: map[string]string{
+				"project_id": projectID,
+				"processor":  event.Processor.Event,
+			},
+			Data: encoded,
 		}))
 	}
 	// NOTE(marclop) should the error be returned to the client? Does it care?

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -24,6 +24,7 @@ import (
 	_ "golang.org/x/tools/cmd/goimports"   // go.mod
 	_ "honnef.co/go/tools/cmd/staticcheck" // go.mod
 
-	_ "github.com/elastic/go-licenser"    // go.mod
 	_ "go.elastic.co/go-licence-detector" // go.mod
+
+	_ "github.com/elastic/go-licenser" // go.mod
 )


### PR DESCRIPTION
Adds the event processor in the PubSub message headers, which will allow subscribers to filter on certain events types. Also adds missing headers in a few files. See https://cloud.google.com/pubsub/docs/subscription-message-filter.