### PR TITLE
context: Enrich / extract metadata (string map)

### DIFF
--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -125,11 +125,10 @@ func NewConsumer(ctx context.Context, cfg ConsumerConfig) (*Consumer, error) {
 		NackHandler: func(msg *pubsub.Message) error {
 			// TODO(marclop) DLQ?
 			partition, offset := partitionOffset(msg.ID)
-			projectID := msg.Attributes["project_id"]
 			cfg.Logger.Error("handling nacked message",
 				zap.Int("partition", partition),
 				zap.Int64("offset", offset),
-				zap.String("project_id", projectID),
+				zap.Any("project_id", msg.Attributes),
 			)
 			return nil // nil is returned to avoid terminating the subscriber.
 		},
@@ -165,22 +164,20 @@ func (c *Consumer) Run(ctx context.Context) error {
 	ctx, c.stopSubscriber = context.WithCancel(ctx)
 	c.mu.Unlock()
 	return c.consumer.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-		projectID := msg.Attributes["project_id"]
-		ctx = queuecontext.WithProject(ctx, projectID)
 		var event model.APMEvent
 		if err := c.cfg.Decoder.Decode(msg.Data, &event); err != nil {
 			defer msg.Nack()
 			partition, offset := partitionOffset(msg.ID)
-			c.cfg.Logger.Error("unable to unmarshal json into model.APMEvent",
+			c.cfg.Logger.Error("unable to decode message.Data into model.APMEvent",
 				zap.Error(err),
 				zap.ByteString("message.value", msg.Data),
 				zap.Int64("offset", offset),
 				zap.Int("partition", partition),
-				zap.String("project_id", projectID),
 			)
 			return
 		}
 		batch := model.Batch{event}
+		ctx = queuecontext.WithMetadata(ctx, msg.Attributes)
 		if err := c.cfg.Processor.ProcessBatch(ctx, &batch); err != nil {
 			defer msg.Nack()
 			partition, offset := partitionOffset(msg.ID)
@@ -188,7 +185,6 @@ func (c *Consumer) Run(ctx context.Context) error {
 				zap.Error(err),
 				zap.Int64("offset", offset),
 				zap.Int("partition", partition),
-				zap.String("project_id", projectID),
 			)
 			return
 		}

--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -128,7 +128,7 @@ func NewConsumer(ctx context.Context, cfg ConsumerConfig) (*Consumer, error) {
 			cfg.Logger.Error("handling nacked message",
 				zap.Int("partition", partition),
 				zap.Int64("offset", offset),
-				zap.Any("project_id", msg.Attributes),
+				zap.Any("attributes", msg.Attributes),
 			)
 			return nil // nil is returned to avoid terminating the subscriber.
 		},

--- a/queuecontext/context.go
+++ b/queuecontext/context.go
@@ -16,24 +16,24 @@
 // under the License.
 
 // Package queuecontext provides convenient wrappers for storing and
-// accessing a stored project identifier.
+// accessing a stored metadata.
 package queuecontext
 
 import "context"
 
-type projectIDKey struct{}
+type metadataKey struct{}
 
-// WithProject enriches a context with a project.
-func WithProject(ctx context.Context, project string) context.Context {
-	return context.WithValue(ctx, projectIDKey{}, project)
+// WithMetadata enriches a context with metadata.
+func WithMetadata(ctx context.Context, metadata map[string]string) context.Context {
+	return context.WithValue(ctx, metadataKey{}, metadata)
 }
 
-// ProjectFromContext returns the project ID from the passed context and a bool
+// MetadataFromContext returns the metadata from the passed context and a bool
 // indicating whether the value is present or not.
-func ProjectFromContext(ctx context.Context) (string, bool) {
-	if v := ctx.Value(projectIDKey{}); v != nil {
-		project, ok := v.(string)
-		return project, ok
+func MetadataFromContext(ctx context.Context) (map[string]string, bool) {
+	if v := ctx.Value(metadataKey{}); v != nil {
+		metadata, ok := v.(map[string]string)
+		return metadata, ok
 	}
-	return "", false
+	return nil, false
 }


### PR DESCRIPTION
Removes the project context enrichment / extraction and instead uses a more versatile and abstract map[string]string to store arbitrary k/v in the context.
