### PR TITLE
kafka: update `Health()` to use `client.Ping()`

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -238,10 +238,11 @@ func (c *Consumer) fetch(ctx context.Context) error {
 	return nil
 }
 
-// Healthy returns an error if the Kafka active broker length dips below 1.
+// Healthy returns an error if the Kafka client fails to reach a discovered
+// broker.
 func (c *Consumer) Healthy() error {
-	if brokers := c.client.DiscoveredBrokers(); len(brokers) < 1 {
-		return fmt.Errorf("number of brokers below 1")
+	if err := c.client.Ping(context.Background()); err != nil {
+		return fmt.Errorf("health probe: %w", err)
 	}
 	return nil
 }

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -191,9 +191,11 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 	return nil
 }
 
+// Healthy returns an error if the Kafka client fails to reach a discovered
+// broker.
 func (p *Producer) Healthy() error {
-	if brokers := p.client.DiscoveredBrokers(); len(brokers) < 1 {
-		return fmt.Errorf("number of active brokers below 1")
+	if err := p.client.Ping(context.Background()); err != nil {
+		return fmt.Errorf("health probe: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Updates the `Health` method for the Kafka producer and consumer to use the `client.Ping()` which forces the client to reach out to a Broker.