### PR TITLE
Tilt: Add kafka Helm chart, pubsublite tf module

### DIFF
--- a/infra/k8s/kafka/.helmignore
+++ b/infra/k8s/kafka/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/infra/k8s/kafka/Chart.yaml
+++ b/infra/k8s/kafka/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kafka
+description: Creates a Kafka cluster with optional topics using the strimzi Operator
+type: application
+version: 0.1.0

--- a/infra/k8s/kafka/templates/kafka-single.yaml
+++ b/infra/k8s/kafka/templates/kafka-single.yaml
@@ -1,0 +1,34 @@
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: {{ $.Values.cluster | default "kafka" }}
+  namespace: {{ .Values.namespace | default "kafka" }}
+spec:
+  kafka:
+    version: 3.3.2
+    replicas: 1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+      inter.broker.protocol.version: "3.3"
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 1
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/infra/k8s/kafka/templates/topic.yaml
+++ b/infra/k8s/kafka/templates/topic.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.topics }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.}}
+  namespace: {{ $.Values.namespace | default "kafka" }}
+  labels:
+    strimzi.io/cluster: {{ $.Values.cluster | default "kafka" }}
+spec:
+  partitions: {{ $.Values.partitions | default 1 }}
+  replicas: {{ $.Values.replicas | default 1 }}
+{{- end }}

--- a/infra/k8s/kafka/values.yaml
+++ b/infra/k8s/kafka/values.yaml
@@ -1,0 +1,4 @@
+partitions: 1
+replicas: 1
+cluster: kafka
+namespace: kafka

--- a/infra/module/pubsublite/main.tf
+++ b/infra/module/pubsublite/main.tf
@@ -1,0 +1,87 @@
+locals {
+  suffix      = var.suffix
+  region      = var.region
+  reservation = var.reservation
+  topics      = toset(var.topics)
+}
+
+resource "google_pubsub_lite_topic" "topic" {
+  for_each = local.topics
+
+  name    = "${var.prefix}.${each.key}${local.suffix}"
+  project = data.google_project.project.number
+
+  partition_config {
+    count = var.partition_count
+    capacity {
+      // 4MiB is the minimum allowed throughput per partition.
+      publish_mib_per_sec   = 4
+      subscribe_mib_per_sec = 4
+    }
+  }
+
+  retention_config {
+    period = "3600s" // 1h.
+
+    per_partition_bytes = 32212254720 // Minimum
+  }
+
+  reservation_config {
+    throughput_reservation = "projects/${data.google_project.project.number}/locations/${local.region}/reservations/${local.reservation}"
+  }
+}
+
+resource "google_pubsub_lite_subscription" "topic" {
+  for_each = var.create_subscription ? local.topics : []
+
+  name  = "${var.prefix}.${each.key}${local.suffix}"
+  topic = google_pubsub_lite_topic.topic[each.key].name
+  delivery_config {
+    delivery_requirement = "DELIVER_AFTER_STORED"
+  }
+}
+
+data "google_project" "project" {}
+
+# REQUIRED variables
+
+variable "prefix" {
+  description = "Required resource topic prefix"
+  type        = string
+}
+
+variable "topics" {
+  description = "Required topics to create, the format will be {prefix}.{topic}{suffix}"
+  type        = list(string)
+}
+
+variable "reservation" {
+  description = "Required existing reservation to use for ALL the topics"
+  type        = string
+}
+
+# OPTIONAL variables
+
+variable "suffix" {
+  description = "Optionalthe topic suffix"
+  default     = ""
+  type        = string
+}
+
+variable "create_subscription" {
+  description = "Whether or not to create a subscription for each of the topics. The subscription name wil be the same as the topic name"
+  default     = false
+  type        = bool
+}
+
+variable "region" {
+  description = "Optional GCP region"
+  default     = "asia-south1"
+  type        = string
+}
+
+variable "partition_count" {
+  description = "Optional partitions per topic"
+  default     = 1
+  type        = number
+}

--- a/infra/module/pubsublite/main.tf
+++ b/infra/module/pubsublite/main.tf
@@ -63,7 +63,7 @@ variable "reservation" {
 # OPTIONAL variables
 
 variable "suffix" {
-  description = "Optionalthe topic suffix"
+  description = "Optional topic suffix"
   default     = ""
   type        = string
 }

--- a/queue.Tiltfile
+++ b/queue.Tiltfile
@@ -1,0 +1,37 @@
+load('ext://helm_resource', 'helm_resource', 'helm_repo')
+
+def validate_queue(queue_type):
+    if queue_type not in ['kafka', 'pubsublite', 'noop']:
+        fail("invalid queue_type specified: {}".format(queue_type))
+
+def provision_kafka(path='.', namespace='kafka', topics=[], partitions=5):
+    QUEUE_NAME='kafka'
+    kafka_chart_path = os.path.join(path, 'infra/k8s/kafka')
+    k8s_yaml(local(
+        'helm template {} --set-json=\'topics={}\' --set=partitions={} --set=namespace={} --set=cluster={}'.format(
+            kafka_chart_path, topics, partitions, namespace, QUEUE_NAME,
+        ),
+    ))
+    watch_file(kafka_chart_path)
+    helm_repo('strimzi', 'https://strimzi.io/charts/')
+    helm_resource('kafka-operator',
+        'strimzi/strimzi-kafka-operator', 
+        namespace=QUEUE_NAME,
+        labels=QUEUE_NAME
+    )
+    k8s_resource(
+        objects=["{}:Kafka:{}".format(QUEUE_NAME, namespace)],
+        new_name=QUEUE_NAME,
+        pod_readiness='wait',
+        extra_pod_selectors=[{'strimzi.io/controller-name': 'kafka-kafka'}],
+        discovery_strategy='selectors-only',
+        labels=QUEUE_NAME
+    )
+
+def provision_pubsublite(path, topics=[], create_subscription=False):
+    os.putenv("TF_VAR_topics", "{}".format(topics))
+    os.putenv("TF_VAR_prefix", "dev-{}".format(os.getenv("USER")))
+    os.putenv("TF_VAR_create_subscription", "{}".format(create_subscription))
+    if config.tilt_subcommand == "up":
+        print("provisioning pubsublite resources...")
+        print(local("make -C {} apply".format(path)))


### PR DESCRIPTION
Adds a new Kafka Helm chart, which creates a new Kafka ephemeral cluster with an optional number of Kafka topics, and a pubsublite Terraform module to provision an arbitrary number of pubsublite topics, optionally creating subscriptions for each of those.

Last, `queue.Tiltfile` is meant to be loaded by a Tiltfile to provision the desired "queue" type.

Part of #42