### PR TITLE
action: export GH workflow runs to APM data

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,18 @@
+---
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows:
+      - ci
+    types: [completed]
+
+jobs:
+  otel-export-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@main
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
This will help to visualise the GitHub workflow runs as APM traces

It requires a couple of secrets to be added, though I'm not admin, so I can send you over them 

Cheers
