### PR TITLE
kafka(producer): Fix async producing

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -184,7 +184,7 @@ func (p *Producer) Close() error {
 
 // ProcessBatch publishes the batch to the kafka topic inferred from the
 // configured TopicRouter. If the Producer is synchronous, it waits until all
-// messages have been produced to PubSub Lite, otherwise, returns as soon as
+// messages have been produced to Kafka, otherwise, returns as soon as
 // the messages have been stored in the producer's buffer.
 func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 	// Take a read lock to prevent Close from closing the client

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -171,6 +171,10 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 }
 
 // Close stops the producer
+//
+// This call is blocking and will cause all the underlying clients to stop
+// producing. If producing is asynchronous, it'll block until all messages
+// have been produced. After Close() is called, Producer cannot be reused.
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -178,7 +182,10 @@ func (p *Producer) Close() error {
 	return nil
 }
 
-// ProcessBatch publishes the events in batch to the specified Kafka topic.
+// ProcessBatch publishes the batch to the kafka topic inferred from the
+// configured TopicRouter. If the Producer is synchronous, it waits until all
+// messages have been produced to PubSub Lite, otherwise, returns as soon as
+// the messages have been stored in the producer's buffer.
 func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 	// Take a read lock to prevent Close from closing the client
 	// while we're attempting to produce records.
@@ -212,6 +219,10 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 			return fmt.Errorf("failed to encode event: %w", err)
 		}
 		record.Value = encoded
+		if !p.cfg.Sync {
+			// Detach the context from its deadline or cancellation.
+			ctx = queuecontext.DetachedContext(ctx)
+		}
 		p.client.Produce(ctx, record, func(msg *kgo.Record, err error) {
 			defer wg.Done()
 			if err != nil {

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -48,64 +48,79 @@ func TestNewProducerBasic(t *testing.T) {
 	// * Producing a set number of records
 	// * Content contains headers from arbitrary metadata.
 	// * Record.Value can be decoded with the same codec.
-	topic := "default-topic"
-	client, brokers := newClusterWithTopics(t, topic)
-	codec := json.JSON{}
-	producer, err := NewProducer(ProducerConfig{
-		Brokers: brokers,
-		Sync:    true,
-		Logger:  zap.NewNop(),
-		Encoder: codec,
-		TopicRouter: func(event model.APMEvent) apmqueue.Topic {
-			return apmqueue.Topic(topic)
-		},
-	})
-	require.NoError(t, err)
+	test := func(t *testing.T, sync bool) {
+		t.Run(fmt.Sprintf("sync_%t", sync), func(t *testing.T) {
+			topic := "default-topic"
+			client, brokers := newClusterWithTopics(t, topic)
+			codec := json.JSON{}
+			producer, err := NewProducer(ProducerConfig{
+				Brokers: brokers,
+				Sync:    sync,
+				Logger:  zap.NewNop(),
+				Encoder: codec,
+				TopicRouter: func(event model.APMEvent) apmqueue.Topic {
+					return apmqueue.Topic(topic)
+				},
+			})
+			require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
 
-	ctx = queuecontext.WithMetadata(ctx, map[string]string{"a": "b", "c": "d"})
-	batch := model.Batch{
-		{Transaction: &model.Transaction{ID: "1"}},
-		{Transaction: &model.Transaction{ID: "2"}},
-	}
-	require.NoError(t, producer.ProcessBatch(ctx, &batch))
+			ctx = queuecontext.WithMetadata(ctx, map[string]string{"a": "b", "c": "d"})
+			batch := model.Batch{
+				{Transaction: &model.Transaction{ID: "1"}},
+				{Transaction: &model.Transaction{ID: "2"}},
+			}
+			if !sync {
+				// Cancel the context before calling processBatch
+				var c func()
+				var ctxCancelled context.Context
+				ctxCancelled, c = context.WithCancel(ctx)
+				c()
+				require.NoError(t, producer.ProcessBatch(ctxCancelled, &batch))
+			} else {
+				require.NoError(t, producer.ProcessBatch(ctx, &batch))
+			}
 
-	client.AddConsumeTopics(topic)
-	for i := 0; i < len(batch); i++ {
-		fetches := client.PollRecords(ctx, 1)
-		require.NoError(t, fetches.Err())
+			client.AddConsumeTopics(topic)
+			for i := 0; i < len(batch); i++ {
+				fetches := client.PollRecords(ctx, 1)
+				require.NoError(t, fetches.Err())
 
-		// Assert length.
-		records := fetches.Records()
-		assert.Len(t, records, 1)
+				// Assert length.
+				records := fetches.Records()
+				assert.Len(t, records, 1)
 
-		var event model.APMEvent
-		record := records[0]
-		err := codec.Decode(record.Value, &event)
-		require.NoError(t, err)
+				var event model.APMEvent
+				record := records[0]
+				err := codec.Decode(record.Value, &event)
+				require.NoError(t, err)
 
-		// Assert contents and decoding.
-		assert.Equal(t, model.APMEvent{
-			Transaction: &model.Transaction{ID: fmt.Sprint(i + 1)},
-		}, event)
+				// Assert contents and decoding.
+				assert.Equal(t, model.APMEvent{
+					Transaction: &model.Transaction{ID: fmt.Sprint(i + 1)},
+				}, event)
 
-		// Sort headers and assert their existence.
-		sort.Slice(record.Headers, func(i, j int) bool {
-			return record.Headers[i].Key < record.Headers[j].Key
+				// Sort headers and assert their existence.
+				sort.Slice(record.Headers, func(i, j int) bool {
+					return record.Headers[i].Key < record.Headers[j].Key
+				})
+				assert.Equal(t, []kgo.RecordHeader{
+					{Key: "a", Value: []byte("b")},
+					{Key: "c", Value: []byte("d")},
+				}, record.Headers)
+			}
+
+			// Assert no more records have been produced. A nil context is used to
+			// cause PollRecords to return immediately.
+			//lint:ignore SA1012 passing a nil context is a valid use for this call.
+			fetches := client.PollRecords(nil, 1)
+			assert.Len(t, fetches.Records(), 0)
 		})
-		assert.Equal(t, []kgo.RecordHeader{
-			{Key: "a", Value: []byte("b")},
-			{Key: "c", Value: []byte("d")},
-		}, record.Headers)
 	}
-
-	// Assert no more records have been produced. A nil context is used to
-	// cause PollRecords to return immediately.
-	//lint:ignore SA1012 passing a nil context is a valid use for this call.
-	fetches := client.PollRecords(nil, 1)
-	assert.Len(t, fetches.Records(), 0)
+	test(t, true)
+	test(t, false)
 }
 
 func newClusterWithTopics(t *testing.T, topics ...string) (*kgo.Client, []string) {

--- a/queuecontext/context.go
+++ b/queuecontext/context.go
@@ -37,3 +37,23 @@ func MetadataFromContext(ctx context.Context) (map[string]string, bool) {
 	}
 	return nil, false
 }
+
+// DetachedContext returns a new context detached from the lifetime
+// of ctx, but which still returns the values of ctx.
+//
+// DetachedContext can be used to maintain the context values required
+// to correlate events, but where the operation is "fire-and-forget",
+// and should not be affected by the deadline or cancellation of ctx.
+func DetachedContext(ctx context.Context) context.Context {
+	return &detachedContext{Context: context.Background(), orig: ctx}
+}
+
+type detachedContext struct {
+	context.Context
+	orig context.Context
+}
+
+// Value returns c.orig.Value(key).
+func (c *detachedContext) Value(key interface{}) interface{} {
+	return c.orig.Value(key)
+}

--- a/queuecontext/context_test.go
+++ b/queuecontext/context_test.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package queuecontext provides convenient wrappers for storing and
+// accessing a stored metadata.
+package queuecontext
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetachedContext(t *testing.T) {
+	// Ensures that the detached context isn't cancelled and any values are
+	// still accessible.
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx := WithMetadata(cancelCtx, map[string]string{"a": "b"})
+	detached := DetachedContext(ctx)
+
+	// Cancel the context
+	cancel()
+	select {
+	case <-detached.Done():
+		t.Fatal("context shouldn't be cancelled")
+	case <-time.After(time.Millisecond):
+	}
+
+	meta, ok := MetadataFromContext(detached)
+	require.True(t, ok)
+	assert.Equal(t, map[string]string{"a": "b"}, meta)
+}


### PR DESCRIPTION
Fixes the async producing by detaching the `context.Context.Deadline` from the passed context in ProcessBatch, but maintaining context.Values that may be defined, which allows trace context to be propagated down to the kgo client.

Closes #53