### PR TITLE
renovate: Update policy, ignore `apm-queue`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,70 @@
   "extends": [
     "config:base"
   ],
-  "automerge": true,
+  "labels": [
+    "renovate"
+  ],
+  "ignoreDeps": [
+    "github.com/elastic/apm-queue"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": [
+        "github.com/elastic/"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
+      "enabled": true,
+      "automerge": true
+    },
+    {
+      "matchPackagePrefixes": [
+        "github.com/elastic/"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": true,
+      "automerge": false
+    },
+    {
+      "excludePackagePrefixes": [
+        "github.com/elastic/"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin"
+      ],
+      "enabled": true,
+      "automerge": true
+    },
+    {
+      "excludePackagePrefixes": [
+        "github.com/elastic/"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": true,
+      "automerge": false
+    },
+    {
+      "excludePackagePrefixes": [
+        "github.com/elastic/"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "enabled": false
+    }
+  ],
   "automergeStrategy": "squash",
+  "automergeType": "branch",
+  "separateMajorMinor": true,
   "gomodTidy": true
 }


### PR DESCRIPTION
Ignores the `github.com/elastic/apm-queue` module, since it's used by `cmd/loadgen` and that dependency is replaced by the contents of the local module.

Additionally, updates the renovate config to match the Elastic policy.