### PR TITLE
kafka(producer): Fix OTel `span.End()`

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -44,10 +45,6 @@ type Encoder interface {
 	// Encode accepts a model.APMEvent and returns the encoded representation.
 	Encode(model.APMEvent) ([]byte, error)
 }
-
-// RecordMutator mutates the record associated with the model.APMEvent.
-// If the RecordMutator returns an error, it is considered fatal.
-type RecordMutator func(model.APMEvent, *kgo.Record) error
 
 // CompressionCodec configures how records are compressed before being sent.
 // Type alias to kgo.CompressionCodec.
@@ -94,10 +91,6 @@ type ProducerConfig struct {
 	// TopicRouter returns the topic where an event should be produced.
 	TopicRouter apmqueue.TopicRouter
 
-	// Mutators holds the list of RecordMutator applied to all the records sent
-	// by the producer. If any errors are returned, the producer will not
-	// produce and return the error in ProcessBatch.
-	Mutators []RecordMutator
 	// SASL configures the kgo.Client to use SASL authorization.
 	SASL sasl.Mechanism
 	// TLS configures the kgo.Client to use TLS for authentication.
@@ -203,10 +196,9 @@ func (p *Producer) Close() error {
 // messages have been produced to Kafka, otherwise, returns as soon as
 // the messages have been stored in the producer's buffer.
 func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
-	ctx, span := p.tracer.Start(ctx, "ProcessBatch", trace.WithAttributes(
+	ctx, span := p.tracer.Start(ctx, "producer.ProcessBatch", trace.WithAttributes(
 		attribute.Int("batch.size", len(*batch)),
 	))
-	defer span.End()
 
 	// Take a read lock to prevent Close from closing the client
 	// while we're attempting to produce records.
@@ -230,14 +222,13 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 			Headers: headers,
 			Topic:   string(p.cfg.TopicRouter(event)),
 		}
-		for _, rm := range p.cfg.Mutators {
-			if err := rm(event, record); err != nil {
-				return fmt.Errorf("failed to apply record mutator: %w", err)
-			}
-		}
 		encoded, err := p.cfg.Encoder.Encode(event)
 		if err != nil {
-			return fmt.Errorf("failed to encode event: %w", err)
+			err = fmt.Errorf("failed to encode event: %w", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.End()
+			return err
 		}
 		record.Value = encoded
 		if !p.cfg.Sync {
@@ -245,8 +236,13 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 			ctx = queuecontext.DetachedContext(ctx)
 		}
 		p.client.Produce(ctx, record, func(msg *kgo.Record, err error) {
-			defer wg.Done()
+			defer func() {
+				wg.Done()
+				span.End()
+			}()
 			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, err.Error())
 				p.cfg.Logger.Error("failed producing message",
 					zap.Error(err),
 					zap.String("topic", msg.Topic),


### PR DESCRIPTION
Fixes the `span.End()` for Async producing. Also, captures any errors in the span if they are reported. Last, removes the RecordMutators that were introduced before TopicRouter.