### PR TITLE
Sleep in producer test to reduce the risk of flaky test

### DIFF
--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -130,13 +130,11 @@ func TestNewProducerBasic(t *testing.T) {
 			fetches := client.PollRecords(nil, 1)
 			assert.Len(t, fetches.Records(), 0)
 
-			// kgo runs an unchecked goroutine to mark all the spans it creates as
-			// finished (and close the spans). So the only way to ensure it ran is to
-			// wait. Without this, we get flaky tests in CI.
-			time.Sleep(time.Millisecond)
-
 			// Assert tracing happened properly
-			assert.Equal(t, spanCount+3, len(exp.GetSpans()))
+			assert.Eventually(t, func() bool {
+				return len(exp.GetSpans()) == spanCount+3
+			}, time.Second, 10*time.Millisecond)
+
 			var span tracetest.SpanStub
 			for _, s := range exp.GetSpans() {
 				if s.Name == "producer.ProcessBatch" {

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -130,8 +130,13 @@ func TestNewProducerBasic(t *testing.T) {
 			fetches := client.PollRecords(nil, 1)
 			assert.Len(t, fetches.Records(), 0)
 
+			// kgo runs an unchecked goroutine to mark all the spans it creates as
+			// finished (and close the spans). So the only way to ensure it ran is to
+			// wait. Without this, we get flaky tests in CI.
+			time.Sleep(time.Millisecond)
+
 			// Assert tracing happened properly
-			assert.Equal(t, len(exp.GetSpans()), spanCount+3)
+			assert.Equal(t, spanCount+3, len(exp.GetSpans()))
 			var span tracetest.SpanStub
 			for _, s := range exp.GetSpans() {
 				if s.Name == "producer.ProcessBatch" {


### PR DESCRIPTION
franz-go runs the hooks to finish events in an unchecked goroutine:

https://github.com/twmb/franz-go/blob/master/pkg/kgo/producer.go#L436-L440

This method calls `finishPromises`, which calls `OnProduceRecordUnbuffered`, which is the hook that kotel uses to end the span.

Because of that, the check on the number of created spans is flaky: https://github.com/elastic/apm-queue/actions/runs/4763014463/jobs/8466352708

We don't have any way to know whether kgo has finished running the goroutine. So by sleeping for a millisecond, we reduce the risk of the flaky issue happening.
If kgo took more than 1ms to process the hooks, that seems like something which would be a performance issue to investigate anyway.