### PR TITLE
systemtest: increase terraform installer timeout

### DIFF
--- a/systemtest/infra.go
+++ b/systemtest/infra.go
@@ -47,7 +47,10 @@ var terraformExec string
 func installTerraform(ctx context.Context) (string, error) {
 	var err error
 	terraformExecOnce.Do(func() {
-		installer := &releases.LatestVersion{Product: product.Terraform}
+		installer := &releases.LatestVersion{
+			Product: product.Terraform,
+			Timeout: 5 * time.Minute,
+		}
 		terraformExec, err = installer.Install(ctx)
 		return
 	})


### PR DESCRIPTION
Increase terraform installation timeout. Mostly relevant for people with a slow internet connection.

The default timeout is not enough and systemtests will fail with a generic error "context cancelled"