### PR TITLE
systemtest: wrap provisioning errors for clarity

### DIFF
--- a/systemtest/infra_kafka.go
+++ b/systemtest/infra_kafka.go
@@ -115,7 +115,7 @@ func ProvisionKafka(ctx context.Context, cfg KafkaConfig) error {
 		return err
 	}
 	if err := tf.Init(ctx, tfexec.Upgrade(true)); err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform init: %w", err)
 	}
 	// Create a dummy topic so the infrastructure awaits until all the required
 	// infrastructure is available. It will be destroyed during the first test.
@@ -124,7 +124,7 @@ func ProvisionKafka(ctx context.Context, cfg KafkaConfig) error {
 	}
 	jsonTopics, err := json.Marshal(cfg.Topics)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal topics: %w", err)
 	}
 	namespaceVar := tfexec.Var(fmt.Sprintf("namespace=%s", cfg.Namespace))
 	nameVar := tfexec.Var(fmt.Sprintf("name=%s", cfg.Name))
@@ -135,16 +135,16 @@ func ProvisionKafka(ctx context.Context, cfg KafkaConfig) error {
 		tf.Destroy(ctx, topicsVar, namespaceVar, nameVar)
 	})
 	if err := tf.Apply(ctx, topicsVar, namespaceVar, nameVar); err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform apply: %w", err)
 	}
 	tfOutput, err := tf.Output(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform output: %w", err)
 	}
 	if raw, ok := tfOutput[KafkaBrokersKey]; ok {
 		var brokers []string
 		if err := json.Unmarshal(raw.Value, &brokers); err != nil {
-			return err
+			return fmt.Errorf("failed to unmarshal brokers: %w", err)
 		}
 		if len(brokers) > 0 {
 			SetKafkaBrokers(brokers...)
@@ -170,7 +170,7 @@ func ProvisionKafka(ctx context.Context, cfg KafkaConfig) error {
 			)
 		})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to run port forward: %w", err)
 		}
 	}
 	logger().Info("Kafka infastructure fully provisioned!")

--- a/systemtest/infra_pubsublite.go
+++ b/systemtest/infra_pubsublite.go
@@ -67,15 +67,15 @@ func ProvisionPubSubLite(ctx context.Context, cfg PubSubLiteConfig) error {
 	logger().Infof("provisioning PubSubLite infrastructure with config: %+v", cfg)
 	tf, err := NewTerraform(ctx, cfg.TFPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create terraform: %w", err)
 	}
 	if err := tf.Init(ctx, tfexec.Upgrade(true)); err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform init: %w", err)
 	}
 
 	jsonTopics, err := json.Marshal(cfg.Topics)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal topics: %w", err)
 	}
 	projectVar := tfexec.Var(fmt.Sprintf("project=%s", cfg.Project))
 	regionVar := tfexec.Var(fmt.Sprintf("region=%s", cfg.Region))
@@ -87,7 +87,7 @@ func ProvisionPubSubLite(ctx context.Context, cfg PubSubLiteConfig) error {
 		tf.Destroy(ctx, projectVar, regionVar, suffixVar, topicsVar)
 	})
 	if err := tf.Apply(ctx, projectVar, regionVar, suffixVar, topicsVar); err != nil {
-		return err
+		return fmt.Errorf("failed to run terraform apply: %w", err)
 	}
 	logger().Info("PubSubLite infastructure fully provisioned!")
 	return nil

--- a/systemtest/main_test.go
+++ b/systemtest/main_test.go
@@ -21,6 +21,7 @@ package systemtest
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -37,10 +38,16 @@ func testMain(m *testing.M) int {
 	defer cancel()
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		return ProvisionKafka(ctx, newLocalKafkaConfig())
+		if err := ProvisionKafka(ctx, newLocalKafkaConfig()); err != nil {
+			return fmt.Errorf("failed to provision kafka: %w", err)
+		}
+		return nil
 	})
 	g.Go(func() error {
-		return ProvisionPubSubLite(ctx, newPubSubLiteConfig())
+		if err := ProvisionPubSubLite(ctx, newPubSubLiteConfig()); err != nil {
+			return fmt.Errorf("failed to provision pubsublite: %w", err)
+		}
+		return nil
 	})
 	if !skipDestroy {
 		defer Destroy()


### PR DESCRIPTION
While debugging https://github.com/elastic/apm-queue/pull/109 I received a generic error: "context cancelled". 

Wrapping errors should help to undestand where the error is coming from.