### PR TITLE
ci: add go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ lint: tools/go.mod
 	go run -modfile=tools/go.mod honnef.co/go/tools/cmd/staticcheck -checks=all ./...
 	go list -m -json $(MODULE_DEPS) | go run -modfile=tools/go.mod go.elastic.co/go-licence-detector \
 		-includeIndirect -rules tools/notice/rules.json -validate
+	go mod tidy
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ lint: tools/go.mod
 	go run -modfile=tools/go.mod honnef.co/go/tools/cmd/staticcheck -checks=all ./...
 	go list -m -json $(MODULE_DEPS) | go run -modfile=tools/go.mod go.elastic.co/go-licence-detector \
 		-includeIndirect -rules tools/notice/rules.json -validate
-	go mod tidy
+	go mod tidy && git diff --exit-code
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Closes https://github.com/elastic/apm-queue/issues/106

### What

Run `go mod tidy` within the `lint` context so the CI will run it too.