### PR TITLE
systemtest: Use `ctx.Background` for `tf.Destroy`

### DIFF
--- a/systemtest/infra_kafka.go
+++ b/systemtest/infra_kafka.go
@@ -132,7 +132,9 @@ func ProvisionKafka(ctx context.Context, cfg KafkaConfig) error {
 	// Ensure terraform destroy runs once per TF path.
 	RegisterDestroy(cfg.TFPath, func() {
 		logger().Info("destroying provisioned Kafka infrastructure...")
-		tf.Destroy(ctx, topicsVar, namespaceVar, nameVar)
+		if err := tf.Destroy(context.Background(), topicsVar, namespaceVar, nameVar); err != nil {
+			logger().Error(err)
+		}
 	})
 	if err := tf.Apply(ctx, topicsVar, namespaceVar, nameVar); err != nil {
 		return fmt.Errorf("failed to run terraform apply: %w", err)

--- a/systemtest/infra_pubsublite.go
+++ b/systemtest/infra_pubsublite.go
@@ -84,7 +84,9 @@ func ProvisionPubSubLite(ctx context.Context, cfg PubSubLiteConfig) error {
 	// Ensure terraform destroy runs once per TF path.
 	RegisterDestroy(cfg.TFPath, func() {
 		logger().Info("destroying provisioned PubSubLite infrastructure...")
-		tf.Destroy(ctx, projectVar, regionVar, suffixVar, topicsVar)
+		if err := tf.Destroy(context.Background(), projectVar, regionVar, suffixVar, topicsVar); err != nil {
+			logger().Error(err)
+		}
 	})
 	if err := tf.Apply(ctx, projectVar, regionVar, suffixVar, topicsVar); err != nil {
 		return fmt.Errorf("failed to run terraform apply: %w", err)


### PR DESCRIPTION
Use `context.Background()` for the `tf.Destroy` call, since otherwise the destruction will be tied to the test context, which may be canceled by the time it is called. Also log any errors from `tf.Destroy`.