### PR TITLE
feat: pass context to health checks

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -291,8 +291,8 @@ func (c *Consumer) fetch(ctx context.Context) error {
 
 // Healthy returns an error if the Kafka client fails to reach a discovered
 // broker.
-func (c *Consumer) Healthy() error {
-	if err := c.client.Ping(context.Background()); err != nil {
+func (c *Consumer) Healthy(ctx context.Context) error {
+	if err := c.client.Ping(ctx); err != nil {
 		return fmt.Errorf("health probe: %w", err)
 	}
 	return nil

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -124,9 +124,9 @@ func TestConsumerHealth(t *testing.T) {
 			}
 
 			if tc.expectErr {
-				assert.Error(t, consumer.Healthy())
+				assert.Error(t, consumer.Healthy(context.Background()))
 			} else {
-				assert.NoError(t, consumer.Healthy())
+				assert.NoError(t, consumer.Healthy(context.Background()))
 			}
 		})
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -288,8 +288,8 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 
 // Healthy returns an error if the Kafka client fails to reach a discovered
 // broker.
-func (p *Producer) Healthy() error {
-	if err := p.client.Ping(context.Background()); err != nil {
+func (p *Producer) Healthy(ctx context.Context) error {
+	if err := p.client.Ping(ctx); err != nil {
 		return fmt.Errorf("health probe: %w", err)
 	}
 	return nil

--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -233,7 +233,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 }
 
 // Healthy returns an error if the consumer isn't healthy.
-func (c *Consumer) Healthy() error {
+func (c *Consumer) Healthy(ctx context.Context) error {
 	return nil // TODO(marclop)
 }
 

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -273,7 +273,7 @@ func blockUntilProduced(ctx context.Context, res []resTopic, logger *zap.Logger)
 	}
 }
 
-func (p *Producer) Healthy() error {
+func (p *Producer) Healthy(ctx context.Context) error {
 	return nil // TODO(marclop)
 }
 

--- a/queue.go
+++ b/queue.go
@@ -44,7 +44,7 @@ type Consumer interface {
 	// Run executes the consumer in a blocking manner.
 	Run(ctx context.Context) error
 	// Healthy returns an error if the consumer isn't healthy.
-	Healthy() error
+	Healthy(ctx context.Context) error
 	// Close closes the consumer.
 	Close() error
 }
@@ -53,7 +53,7 @@ type Consumer interface {
 type Producer interface {
 	model.BatchProcessor
 	// Healthy returns an error if the producer isn't healthy.
-	Healthy() error
+	Healthy(ctx context.Context) error
 	// Close closes the producer.
 	Close() error
 }


### PR DESCRIPTION
Pass context to healthcheck methods. Useful to make sure the request context is passed on. 

Closes https://github.com/elastic/apm-queue/issues/96