### PR TITLE
pubsublite: remove Subscription.Validate method

### DIFF
--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -87,21 +87,6 @@ func (s Subscription) String() string {
 	)
 }
 
-// Validate ensures the subscription is valid.
-func (s Subscription) Validate() error {
-	var errs []error
-	if s.Name == "" {
-		errs = append(errs, errors.New("pubsublite: subscription: name must be set"))
-	}
-	if s.Project == "" {
-		errs = append(errs, errors.New("pubsublite: subscription: project must be set"))
-	}
-	if s.Region == "" {
-		errs = append(errs, errors.New("pubsublite: subscription: region must be set"))
-	}
-	return errors.Join(errs...)
-}
-
 // Validate ensures the configuration is valid, otherwise, returns an error.
 func (cfg ConsumerConfig) Validate() error {
 	var errs []error


### PR DESCRIPTION
This is no longer required now that Subscription
is derived from topics and GCP region/project.
We can probably unexport Subscription, but I'll
leave that for another day.