### PR TITLE
kafka(consumer): Fix At Least Once delivery commit

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -249,6 +249,15 @@ func TestConsumerDelivery(t *testing.T) {
 			processed: 11,
 			errored:   1,
 		},
+		"1_produced_1_poll_ALOD": {
+			deliveryType:   apmqueue.AtLeastOnceDeliveryType,
+			initialRecords: 1,
+			maxPollRecords: 1,
+			lastRecords:    0,
+
+			processed: 1,
+			errored:   1,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Description

Update the partition consumer to skip committing offsets of records that have failed processing when AtLeastOnceDelivery is used. May not cause re-processing of records if newer records are produced to the partition, unless the consumer crashes or the partition is reassigned to an another consumer in the consumer group. This is still preferrable to committing the offset of a failed record, given that AtLeastOnceDelivery is set.

## Related issues

Fixes Kafka failures in #116 