### PR TITLE
fix: flush events when closing the kafka producer

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -214,6 +214,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.client.Flush(context.Background())
 	p.client.Close()
 	return nil
 }


### PR DESCRIPTION
Flush events when closing the producer.

This leads to event loss which can be identified when testing lossless graceful shutdown with an async producer.

The logs will contain the following messages:

```
ERROR   failed producing message        {"error": "client closed", "topic": "topic", "offset": 0, "partition": 0, "headers": null}
```

As a solution, we make sure that any buffered events is flushed before closing the client.