### PR TITLE
test: add lossless graceful shutdown test

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -369,7 +369,7 @@ func TestConsumerDelivery(t *testing.T) {
 	}
 }
 
-func TestGracefulSutdown(t *testing.T) {
+func TestConsumerGracefulShutdown(t *testing.T) {
 	test := func(t testing.TB, dt apmqueue.DeliveryType) {
 		client, brokers := newClusterWithTopics(t, "topic")
 		var codec json.JSON


### PR DESCRIPTION
Rename consumer test to avoid name conflicts.

Add a test to verify lossless graceful shutdown for kafka producers (both sync and async, both delivery types).

The test is starting a producer to process events and attempt to close it after processing started*.

The expected outcome is to lose no events. This is verified by a consumer fetching from kafka and verifying that the events are actually there.


*we don't really have a hook/way to close the producer in the middle of processing so we abuse json marshaling to do it. There is a comment in the test that explain the flow for documentation purpose.

Blocked by https://github.com/elastic/apm-queue/pull/130