### PR TITLE
fix: do not panic when trying to close the pubsub producer multiple time

### DIFF
--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -159,6 +159,11 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	select{
+	case <-p.closed:
+		return nil
+	default:
+	}
 	p.producers.Range(func(key, value any) bool {
 		value.(*pscompat.PublisherClient).Stop()
 		return true

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -159,7 +159,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	select{
+	select {
 	case <-p.closed:
 		return nil
 	default:


### PR DESCRIPTION
Another issue discovered while working on https://github.com/elastic/apm-queue/pull/116

This PR update the pubsub producer to not panic when closed multiple times. The behaviour is consistent with the kafka producer.