### PR TITLE
producer: Add ConcurrentClose test, minor fixes

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -214,7 +214,9 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 func (p *Producer) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.client.Flush(context.Background())
+	if err := p.client.Flush(context.Background()); err != nil {
+		return err
+	}
 	p.client.Close()
 	return nil
 }
@@ -283,7 +285,6 @@ func (p *Producer) ProcessBatch(ctx context.Context, batch *model.Batch) error {
 	if p.cfg.Sync {
 		wg.Wait()
 	}
-
 	return nil
 }
 

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -166,6 +166,7 @@ func (p *Producer) Close() error {
 	}
 	p.producers.Range(func(key, value any) bool {
 		value.(*pscompat.PublisherClient).Stop()
+		p.producers.Delete(key)
 		return true
 	})
 	close(p.closed)

--- a/pubsublite/producer_test.go
+++ b/pubsublite/producer_test.go
@@ -18,6 +18,7 @@
 package pubsublite
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,4 +58,20 @@ func TestTopicString(t *testing.T) {
 			assert.Equal(t, tt.want, formatTopic(tt.Project, tt.Region, tt.Topic))
 		})
 	}
+}
+
+func TestProducerConcurrentClose(t *testing.T) {
+	producer := Producer{
+		closed:    make(chan struct{}),
+		responses: make(chan []resTopic),
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, producer.Close())
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Updates `kafka.Producer.Close()` to return any errors returned by the `kgo.Client.Flush()` call.

Updates `pubsublite.Producer.Close()` to delete producers that have been stopped.

Adds a `TestProducerConcurrentClose()` for both packages.