### PR TITLE
Properly configure kotel for consumers

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -29,6 +29,8 @@ import (
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/plugin/kotel"
 	"github.com/twmb/franz-go/plugin/kzap"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/elastic/apm-data/model"
@@ -103,6 +105,9 @@ type ConsumerConfig struct {
 
 	// DisableTelemetry disables the OpenTelemetry hook
 	DisableTelemetry bool
+	// TracerProvider allows specifying a custom otel tracer provider.
+	// Defaults to the global one.
+	TracerProvider trace.TracerProvider
 }
 
 // Validate ensures the configuration is valid, otherwise, returns an error.
@@ -139,6 +144,8 @@ type Consumer struct {
 	client   *kgo.Client
 	cfg      ConsumerConfig
 	consumer *consumer
+
+	tracer trace.Tracer
 }
 
 // NewConsumer creates a new instance of a Consumer. The consumer will read from
@@ -197,8 +204,18 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 		cfg.MaxPollRecords = 100
 	}
 
+	tracerProvider := cfg.TracerProvider
+	if tracerProvider == nil {
+		tracerProvider = otel.GetTracerProvider()
+	}
+
 	if !cfg.DisableTelemetry {
-		kotelService := kotel.NewKotel()
+		kotelService := kotel.NewKotel(
+			kotel.WithTracer(kotel.NewTracer(
+				kotel.TracerProvider(tracerProvider),
+			)),
+			kotel.WithMeter(kotel.NewMeter()),
+		)
 		opts = append(opts, kgo.WithHooks(kotelService.Hooks()...))
 	}
 
@@ -213,6 +230,7 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 		cfg:      cfg,
 		client:   client,
 		consumer: consumer,
+		tracer:   tracerProvider.Tracer("kafka"),
 	}, nil
 }
 


### PR DESCRIPTION
#104 properly configured kotel for producers. But I forgot the consumers when setting that up.
This sets it up there too, so we do get consumer traces.