### PR TITLE
test: add systemtest to verify consistent behaviour on shutdown

### DIFF
--- a/systemtest/produce_consume_basic_test.go
+++ b/systemtest/produce_consume_basic_test.go
@@ -293,14 +293,14 @@ func TestShutdown(t *testing.T) {
 		select {
 		case <-got:
 		case <-time.After(30 * time.Second):
-			t.Fatal("timed out while waiting to receive an event")
+			t.Error("timed out while waiting to receive an event")
 		}
 		cancel()
 
 		select {
 		case <-closeCh:
 		case <-time.After(30 * time.Second):
-			t.Fatal("timed out while waiting for consumer to exit")
+			t.Error("timed out while waiting for consumer to exit")
 		}
 	}
 

--- a/systemtest/produce_consume_basic_test.go
+++ b/systemtest/produce_consume_basic_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/elastic/apm-data/model"
 	apmqueue "github.com/elastic/apm-queue"
@@ -265,5 +267,156 @@ func assertBatchFunc(t testing.TB, assertions consumerAssertions) model.BatchPro
 			}
 		}
 		return nil
+	})
+}
+
+func TestShutdown(t *testing.T) {
+	codec := json.JSON{}
+
+	sendEvent := func(producer apmqueue.Producer) {
+		event := model.APMEvent{Transaction: &model.Transaction{ID: "1"}}
+		assert.NoError(t, producer.ProcessBatch(context.Background(), &model.Batch{event}))
+		assert.NoError(t, producer.Close())
+	}
+
+	testCtx := func(t testing.TB, producerF func() apmqueue.Producer, consumerF func() (apmqueue.Consumer, chan struct{})) {
+		sendEvent(producerF())
+
+		consumer, got := consumerF()
+
+		closeCh := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			assert.ErrorIs(t, consumer.Run(ctx), context.Canceled)
+			close(closeCh)
+		}()
+		select {
+		case <-got:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out while waiting to receive an event")
+		}
+		cancel()
+
+		select {
+		case <-closeCh:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out while waiting for consumer to exit")
+		}
+	}
+
+	testClose := func(t testing.TB, producerF func() apmqueue.Producer, consumerF func() (apmqueue.Consumer, chan struct{})) {
+		sendEvent(producerF())
+
+		consumer, got := consumerF()
+
+		closeCh := make(chan struct{})
+		go func() {
+			assert.NoError(t, consumer.Run(context.Background()))
+			close(closeCh)
+		}()
+		select {
+		case <-got:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out while waiting to receive an event")
+		}
+		assert.NoError(t, consumer.Close())
+
+		select {
+		case <-closeCh:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out while waiting for consumer to exit")
+		}
+	}
+
+	t.Run("Kafka", func(t *testing.T) {
+		f := func(t testing.TB) (func() (apmqueue.Consumer, chan struct{}), func() apmqueue.Producer) {
+			logger := zaptest.NewLogger(t, zaptest.Level(zapcore.InfoLevel))
+			topics := SuffixTopics(apmqueue.Topic(t.Name()))
+			topicRouter := func(event model.APMEvent) apmqueue.Topic {
+				return apmqueue.Topic(topics[0])
+			}
+			require.NoError(t, ProvisionKafka(context.Background(),
+				newLocalKafkaConfig(topics...),
+			))
+
+			consumerF := func() (apmqueue.Consumer, chan struct{}) {
+				received := make(chan struct{})
+				return newKafkaConsumer(t, kafka.ConsumerConfig{
+					Logger:  logger,
+					Decoder: codec,
+					Topics:  topics,
+					GroupID: "groupid",
+					Processor: model.ProcessBatchFunc(func(ctx context.Context, b *model.Batch) error {
+						close(received)
+						return nil
+					}),
+				}), received
+			}
+
+			producerF := func() apmqueue.Producer {
+				return newKafkaProducer(t, kafka.ProducerConfig{
+					Logger:      logger,
+					Encoder:     codec,
+					TopicRouter: topicRouter,
+					Sync:        true,
+				})
+			}
+			return consumerF, producerF
+		}
+
+		t.Run("ctx", func(t *testing.T) {
+			consumerF, producerF := f(t)
+			testCtx(t, producerF, consumerF)
+		})
+		t.Run("close", func(t *testing.T) {
+			consumerF, producerF := f(t)
+			testClose(t, producerF, consumerF)
+		})
+
+	})
+
+	t.Run("PubSub", func(t *testing.T) {
+		f := func(t testing.TB) (func() (apmqueue.Consumer, chan struct{}), func() apmqueue.Producer) {
+			logger := zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
+			topics := SuffixTopics(apmqueue.Topic(t.Name()))
+			topicRouter := func(event model.APMEvent) apmqueue.Topic {
+				return apmqueue.Topic(topics[0])
+			}
+			require.NoError(t, ProvisionPubSubLite(context.Background(),
+				newPubSubLiteConfig(topics...),
+			))
+
+			consumerF := func() (apmqueue.Consumer, chan struct{}) {
+				received := make(chan struct{})
+				return newPubSubLiteConsumer(context.Background(), t, pubsublite.ConsumerConfig{
+					Logger:  logger,
+					Decoder: codec,
+					Topics:  topics,
+					Processor: model.ProcessBatchFunc(func(ctx context.Context, b *model.Batch) error {
+						close(received)
+						return nil
+					}),
+				}), received
+
+			}
+			producerF := func() apmqueue.Producer {
+				return newPubSubLiteProducer(t, pubsublite.ProducerConfig{
+					Logger:      logger,
+					Encoder:     codec,
+					TopicRouter: topicRouter,
+					Sync:        true,
+				})
+			}
+			return consumerF, producerF
+		}
+
+		t.Run("ctx", func(t *testing.T) {
+			consumerF, producerF := f(t)
+			testCtx(t, producerF, consumerF)
+		})
+		t.Run("close", func(t *testing.T) {
+			consumerF, producerF := f(t)
+			testClose(t, producerF, consumerF)
+		})
 	})
 }


### PR DESCRIPTION
Add a systemtest to verify consistent behaviour on shutdown.

The test is creating a producer, sendin an event, creating a consumer and finally closing the consumer.

Consumer is closed in two ways:
- ctx is canceled
- consumer is closed


Related https://github.com/elastic/apm-queue/issues/147