### PR TITLE
consumer(kafka): Fix close deadlock, update errors

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -336,7 +336,9 @@ func TestConsumerDelivery(t *testing.T) {
 			consumer := newConsumer(t, cfg)
 			go func() {
 				err := consumer.Run(ctx)
-				assert.Error(t, err)
+				if err != nil {
+					assert.Equal(t, ErrCommitFailed, err)
+				}
 			}()
 
 			// Wait until the batch processor function is called.
@@ -369,7 +371,7 @@ func TestConsumerDelivery(t *testing.T) {
 			cfg.Logger = baseLogger.Named("2")
 			consumer = newConsumer(t, cfg)
 			go func() {
-				assert.ErrorIs(t, consumer.Run(ctx), context.Canceled)
+				assert.NoError(t, consumer.Run(ctx))
 			}()
 			// Wait for the first record to be consumed before running any assertion.
 			select {
@@ -481,7 +483,7 @@ func TestMultipleConsumers(t *testing.T) {
 	for i := 0; i < consumers; i++ {
 		go func() {
 			consumer := newConsumer(t, cfg)
-			assert.ErrorIs(t, consumer.Run(ctx), context.Canceled)
+			assert.NoError(t, consumer.Run(ctx))
 		}()
 	}
 
@@ -534,7 +536,7 @@ func TestMultipleConsumerGroups(t *testing.T) {
 		})
 		consumer := newConsumer(t, cfg)
 		go func() {
-			assert.ErrorIs(t, consumer.Run(ctx), context.Canceled)
+			assert.NoError(t, consumer.Run(ctx))
 		}()
 	}
 
@@ -557,24 +559,53 @@ func TestMultipleConsumerGroups(t *testing.T) {
 }
 
 func TestConsumerRunError(t *testing.T) {
-	consumer := newConsumer(t, ConsumerConfig{
-		CommonConfig: CommonConfig{
-			Brokers: []string{"localhost:9092"},
-			Logger:  zap.NewNop(),
-		},
-		Topics:    []apmqueue.Topic{"topic"},
-		GroupID:   "groupid",
-		Decoder:   json.JSON{},
-		Processor: model.ProcessBatchFunc(func(context.Context, *model.Batch) error { return nil }),
+	newConsumer := func(t testing.TB, ready chan struct{}) (*Consumer, *kgo.Client) {
+		client, addr := newClusterWithTopics(t, "topic")
+		consumer := newConsumer(t, ConsumerConfig{
+			CommonConfig: CommonConfig{
+				Brokers: addr,
+				Logger:  zaptest.NewLogger(t),
+			},
+			Topics:  []apmqueue.Topic{"topic"},
+			GroupID: "groupid",
+			Decoder: json.JSON{},
+			Processor: model.ProcessBatchFunc(func(context.Context, *model.Batch) error {
+				select {
+				case <-ready:
+				default:
+					close(ready)
+				}
+				return nil
+			}),
+		})
+		return consumer, client
+	}
+	t.Run("context.Cancelled", func(t *testing.T) {
+		consumer, _ := newConsumer(t, nil)
+		// ctx canceled
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.NoError(t, consumer.Run(ctx))
+		// Returns an error after the consumer has been run.
+		require.Error(t, consumer.Run(context.Background()))
 	})
-
-	// ctx canceled
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	require.Error(t, consumer.Run(ctx))
-
-	consumer.Close()
-	require.Error(t, consumer.Run(context.Background()))
+	t.Run("consumer.Close()", func(t *testing.T) {
+		ready := make(chan struct{})
+		consumer, client := newConsumer(t, ready)
+		go func() {
+			require.NoError(t, consumer.Run(context.Background()))
+		}()
+		produceRecord(context.Background(), t, client, &kgo.Record{
+			Topic: "topic", Value: []byte("{}"),
+		})
+		select {
+		case <-ready:
+			consumer.Close()
+		case <-time.After(time.Second):
+		}
+		// Returns an error after the consumer has been run.
+		require.Error(t, consumer.Run(context.Background()))
+	})
 }
 
 func newConsumer(t testing.TB, cfg ConsumerConfig) *Consumer {

--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -183,7 +183,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 	c.mu.Lock()
 	if c.stopSubscriber != nil {
 		c.mu.Unlock()
-		return errors.New("pubsublite: consumer already started")
+		return apmqueue.ErrConsumerAlreadyRunning
 	}
 	ctx, c.stopSubscriber = context.WithCancel(ctx)
 	c.mu.Unlock()

--- a/queue.go
+++ b/queue.go
@@ -21,9 +21,16 @@ package apmqueue
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/elastic/apm-data/model"
+)
+
+var (
+	// ErrConsumerAlreadyRunning is returned by consumer.Run if it has already
+	// been called.
+	ErrConsumerAlreadyRunning = errors.New("consumer.Run: consumer already running")
 )
 
 const (
@@ -41,7 +48,8 @@ type DeliveryType uint8
 
 // Consumer wraps the implementation details of the consumer implementation.
 type Consumer interface {
-	// Run executes the consumer in a blocking manner.
+	// Run executes the consumer in a blocking manner. Returns
+	// ErrConsumerAlreadyRunning when it has already been called.
 	Run(ctx context.Context) error
 	// Healthy returns an error if the consumer isn't healthy.
 	Healthy(ctx context.Context) error


### PR DESCRIPTION
## Description
Updates the `kafka.Consumer` to behave like the `pubsublite.Consumer`. This includes:

- Returning a `nil` error after the context is cancelled, or the client is closed.
- Returning an error if the consumer has already been started.

## Related issues

Closes #157 
Closes #147 