### PR TITLE
pubsublite: extract project_id from credentials

### DIFF
--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -109,6 +109,9 @@ type Consumer struct {
 
 // NewConsumer creates a new consumer instance for a single subscription.
 func NewConsumer(ctx context.Context, cfg ConsumerConfig) (*Consumer, error) {
+	if err := cfg.CommonConfig.setFromEnv(); err != nil {
+		return nil, fmt.Errorf("pubsublite: failed to set config from environment: %w", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("pubsublite: invalid consumer config: %w", err)
 	}

--- a/pubsublite/manager.go
+++ b/pubsublite/manager.go
@@ -51,6 +51,9 @@ type Manager struct {
 
 // NewManager returns a new Manager with the given config.
 func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if err := cfg.CommonConfig.setFromEnv(); err != nil {
+		return nil, fmt.Errorf("pubsublite: failed to set config from environment: %w", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("pubsublite: invalid manager config: %w", err)
 	}

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -93,6 +93,9 @@ type Producer struct {
 
 // NewProducer creates a new PubSub Lite producer for a single project.
 func NewProducer(cfg ProducerConfig) (*Producer, error) {
+	if err := cfg.CommonConfig.setFromEnv(); err != nil {
+		return nil, fmt.Errorf("pubsublite: failed to set config from environment: %w", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("pubsublite: invalid producer config: %w", err)
 	}


### PR DESCRIPTION
Service account credentials have an associated project, use that as the default for CommonConfig.Project.