### PR TITLE
kafka: set defaults from environment

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package kafka
 
 import (

--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -1,0 +1,79 @@
+package kafka
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestCommonConfig(t *testing.T) {
+	assertValid := func(t *testing.T, expected, in CommonConfig) {
+		t.Helper()
+		err := in.finalize()
+		require.NoError(t, err)
+		assert.Equal(t, expected, in)
+	}
+	assertErrors := func(t *testing.T, cfg CommonConfig, errors ...string) {
+		t.Helper()
+		err := cfg.finalize()
+		assert.EqualError(t, err, strings.Join(errors, "\n"))
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		assertErrors(t, CommonConfig{},
+			"kafka: at least one broker must be set",
+			"kafka: logger must be set",
+		)
+	})
+
+	t.Run("tls_or_dialer", func(t *testing.T) {
+		assertErrors(t, CommonConfig{
+			Brokers: []string{"broker"},
+			Logger:  zap.NewNop(),
+			TLS:     &tls.Config{},
+			Dialer:  func(ctx context.Context, network, address string) (net.Conn, error) { panic("unreachable") },
+		}, "kafka: only one of TLS or Dialer can be set")
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		cfg := CommonConfig{
+			Brokers: []string{"broker"},
+			Logger:  zap.NewNop(),
+		}
+		err := cfg.finalize()
+		assert.NoError(t, err)
+		assert.Equal(t, CommonConfig{
+			Brokers: []string{"broker"},
+			Logger:  zap.NewNop(),
+		}, cfg)
+	})
+
+	t.Run("brokers_from_environment", func(t *testing.T) {
+		t.Setenv("KAFKA_BROKERS", "a,b,c")
+		assertValid(t, CommonConfig{
+			Brokers: []string{"a", "b", "c"},
+			Logger:  zap.NewNop(),
+		}, CommonConfig{Logger: zap.NewNop()})
+	})
+
+	t.Run("saslplain_from_environment", func(t *testing.T) {
+		t.Setenv("KAFKA_USERNAME", "kafka_username")
+		t.Setenv("KAFKA_PASSWORD", "kafka_password")
+		cfg := CommonConfig{
+			Brokers: []string{"broker"},
+			Logger:  zap.NewNop(),
+		}
+		require.NoError(t, cfg.finalize())
+		assert.NotNil(t, cfg.SASL)
+		assert.Equal(t, "PLAIN", cfg.SASL.Name())
+		_, message, err := cfg.SASL.Authenticate(context.Background(), "host")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("\x00kafka_username\x00kafka_password"), message)
+	})
+}

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -72,10 +72,12 @@ type ConsumerConfig struct {
 	Processor model.BatchProcessor
 }
 
-// Validate ensures the configuration is valid, otherwise, returns an error.
-func (cfg ConsumerConfig) Validate() error {
+// finalize ensures the configuration is valid, setting default values from
+// environment variables as described in doc comments, returning an error if
+// any configuration is invalid.
+func (cfg *ConsumerConfig) finalize() error {
 	var errs []error
-	if err := cfg.CommonConfig.Validate(); err != nil {
+	if err := cfg.CommonConfig.finalize(); err != nil {
 		errs = append(errs, err)
 	}
 	if len(cfg.Topics) == 0 {
@@ -107,7 +109,7 @@ type Consumer struct {
 // NewConsumer creates a new instance of a Consumer. The consumer will read from
 // each partition concurrently by using a dedicated goroutine per partition.
 func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("kafka: invalid consumer config: %w", err)
 	}
 	consumer := &consumer{

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -50,10 +50,12 @@ type ManagerConfig struct {
 	TopicConfigs map[string]string
 }
 
-// Validate checks that cfg is valid, and returns an error otherwise.
-func (cfg ManagerConfig) Validate() error {
+// finalize ensures the configuration is valid, setting default values from
+// environment variables as described in doc comments, returning an error if
+// any configuration is invalid.
+func (cfg *ManagerConfig) finalize() error {
 	var errs []error
-	if err := cfg.CommonConfig.Validate(); err != nil {
+	if err := cfg.CommonConfig.finalize(); err != nil {
 		errs = append(errs, err)
 	}
 	if cfg.PartitionCount == 0 {
@@ -72,7 +74,7 @@ type Manager struct {
 
 // NewManager returns a new Manager with the given config.
 func NewManager(cfg ManagerConfig) (*Manager, error) {
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("kafka: invalid manager config: %w", err)
 	}
 	var topicConfigs map[string]*string

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -79,10 +79,12 @@ type ProducerConfig struct {
 	CompressionCodec []CompressionCodec
 }
 
-// Validate checks that cfg is valid, and returns an error otherwise.
-func (cfg ProducerConfig) Validate() error {
+// finalize ensures the configuration is valid, setting default values from
+// environment variables as described in doc comments, returning an error if
+// any configuration is invalid.
+func (cfg ProducerConfig) finalize() error {
 	var errs []error
-	if err := cfg.CommonConfig.Validate(); err != nil {
+	if err := cfg.CommonConfig.finalize(); err != nil {
 		errs = append(errs, err)
 	}
 	if cfg.Encoder == nil {
@@ -105,7 +107,7 @@ type Producer struct {
 
 // NewProducer returns a new Producer with the given config.
 func NewProducer(cfg ProducerConfig) (*Producer, error) {
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("kafka: invalid producer config: %w", err)
 	}
 	var opts []kgo.Opt


### PR DESCRIPTION
If CommonConfig.Brokers is unspecified, look for $KAFKA_BROKERS and treat it as a comma-separated list of broker addresses.

If CommonConfig.SASL is unspecified, look for $KAFKA_USERNAME and $KAFKA_PASSWORD and treat them as SASL/PLAIN credentials.