### PR TITLE
kafka: create separate TopicCreator type

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -35,19 +35,6 @@ import (
 // ManagerConfig holds configuration for managing Kafka topics.
 type ManagerConfig struct {
 	CommonConfig
-
-	// PartitionCount is the number of partitions to assign to
-	// newly created topics.
-	//
-	// Must be non-zero. If PartitonCount is -1, the broker's
-	// default value (requires Kafka 2.4+).
-	PartitionCount int
-
-	// TopicConfigs holds any topic configs to assign to newly
-	// created topics, such as `retention.ms`.
-	//
-	// See https://kafka.apache.org/documentation/#topicconfigs
-	TopicConfigs map[string]string
 }
 
 // finalize ensures the configuration is valid, setting default values from
@@ -58,18 +45,14 @@ func (cfg *ManagerConfig) finalize() error {
 	if err := cfg.CommonConfig.finalize(); err != nil {
 		errs = append(errs, err)
 	}
-	if cfg.PartitionCount == 0 {
-		errs = append(errs, errors.New("kafka: partition count must be non-zero"))
-	}
 	return errors.Join(errs...)
 }
 
 // Manager manages Kafka topics.
 type Manager struct {
-	cfg          ManagerConfig
-	topicConfigs map[string]*string
-	client       *kadm.Client
-	tracer       trace.Tracer
+	cfg    ManagerConfig
+	client *kadm.Client
+	tracer trace.Tracer
 }
 
 // NewManager returns a new Manager with the given config.
@@ -77,22 +60,14 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("kafka: invalid manager config: %w", err)
 	}
-	var topicConfigs map[string]*string
-	if len(cfg.TopicConfigs) != 0 {
-		topicConfigs = make(map[string]*string, len(cfg.TopicConfigs))
-		for k, v := range cfg.TopicConfigs {
-			topicConfigs[k] = kadm.StringPtr(v)
-		}
-	}
 	client, err := cfg.newClient()
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed creating kafka client: %w", err)
 	}
 	return &Manager{
-		cfg:          cfg,
-		topicConfigs: topicConfigs,
-		client:       kadm.NewClient(client),
-		tracer:       cfg.tracerProvider().Tracer("kafka"),
+		cfg:    cfg,
+		client: kadm.NewClient(client),
+		tracer: cfg.tracerProvider().Tracer("kafka"),
 	}, nil
 }
 
@@ -101,63 +76,6 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 func (m *Manager) Close() error {
 	m.client.Close()
 	return nil
-}
-
-// CreateTopics creates one or more topics.
-//
-// Topics that already exist will be left unmodified.
-func (m *Manager) CreateTopics(ctx context.Context, topics ...apmqueue.Topic) error {
-	// TODO(axw) how should we record topics?
-	ctx, span := m.tracer.Start(ctx, "CreateTopics", trace.WithAttributes(
-		semconv.MessagingSystemKey.String("kafka"),
-	))
-	defer span.End()
-
-	topicNames := make([]string, len(topics))
-	for i, topic := range topics {
-		topicNames[i] = string(topic)
-	}
-	responses, err := m.client.CreateTopics(
-		ctx,
-		int32(m.cfg.PartitionCount),
-		-1, // default.replication.factor
-		m.topicConfigs,
-		topicNames...,
-	)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "CreateTopics returned an error")
-		return fmt.Errorf("failed to create kafka topics: %w", err)
-	}
-	createTopicParamsFields := []zap.Field{
-		zap.Int("partition_count", m.cfg.PartitionCount),
-	}
-	if m.cfg.TopicConfigs != nil {
-		createTopicParamsFields = append(createTopicParamsFields,
-			zap.Reflect("topic_configs", m.cfg.TopicConfigs),
-		)
-	}
-	var createErrors []error
-	for _, response := range responses.Sorted() {
-		logger := m.cfg.Logger.With(zap.String("topic", response.Topic))
-		if err := response.Err; err != nil {
-			if errors.Is(err, kerr.TopicAlreadyExists) {
-				logger.Debug("kafka topic already exists")
-			} else {
-				span.RecordError(err)
-				span.SetStatus(codes.Error, "failed to create one or more topic")
-				createErrors = append(createErrors,
-					fmt.Errorf(
-						"failed to create topic %q: %w",
-						response.Topic, err,
-					),
-				)
-			}
-			continue
-		}
-		logger.Info("created kafka topic", createTopicParamsFields...)
-	}
-	return errors.Join(createErrors...)
 }
 
 // DeleteTopics deletes one or more topics.

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -48,9 +48,7 @@ type TopicCreatorConfig struct {
 	TopicConfigs map[string]string
 }
 
-// finalize ensures the configuration is valid, setting default values from
-// environment variables as described in doc comments, returning an error if
-// any configuration is invalid.
+// Validate ensures the configuration is valid, returning an error otherwise.
 func (cfg TopicCreatorConfig) Validate() error {
 	var errs []error
 	if cfg.PartitionCount == 0 {

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -1,0 +1,145 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kafka
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+
+	apmqueue "github.com/elastic/apm-queue"
+)
+
+// TopicCreatorConfig holds configuration for creating Kafka topics.
+type TopicCreatorConfig struct {
+	// PartitionCount is the number of partitions to assign to
+	// newly created topics.
+	//
+	// Must be non-zero. If PartitonCount is -1, the broker's
+	// default value (requires Kafka 2.4+).
+	PartitionCount int
+
+	// TopicConfigs holds any topic configs to assign to newly
+	// created topics, such as `retention.ms`.
+	//
+	// See https://kafka.apache.org/documentation/#topicconfigs
+	TopicConfigs map[string]string
+}
+
+// finalize ensures the configuration is valid, setting default values from
+// environment variables as described in doc comments, returning an error if
+// any configuration is invalid.
+func (cfg TopicCreatorConfig) Validate() error {
+	var errs []error
+	if cfg.PartitionCount == 0 {
+		errs = append(errs, errors.New("kafka: partition count must be non-zero"))
+	}
+	return errors.Join(errs...)
+}
+
+// TopicCreator creates Kafka topics.
+type TopicCreator struct {
+	m                *Manager
+	partitionCount   int
+	origTopicConfigs map[string]string
+	topicConfigs     map[string]*string
+}
+
+// NewTopicCreator returns a new TopicCreator with the given config.
+func (m *Manager) NewTopicCreator(cfg TopicCreatorConfig) (*TopicCreator, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("kafka: invalid topic creator config: %w", err)
+	}
+	var topicConfigs map[string]*string
+	if len(cfg.TopicConfigs) != 0 {
+		topicConfigs = make(map[string]*string, len(cfg.TopicConfigs))
+		for k, v := range cfg.TopicConfigs {
+			topicConfigs[k] = kadm.StringPtr(v)
+		}
+	}
+	return &TopicCreator{
+		m:                m,
+		partitionCount:   cfg.PartitionCount,
+		origTopicConfigs: cfg.TopicConfigs,
+		topicConfigs:     topicConfigs,
+	}, nil
+}
+
+// CreateTopics creates one or more topics.
+//
+// Topics that already exist will be left unmodified.
+func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topic) error {
+	// TODO(axw) how should we record topics?
+	ctx, span := c.m.tracer.Start(ctx, "CreateTopics", trace.WithAttributes(
+		semconv.MessagingSystemKey.String("kafka"),
+	))
+	defer span.End()
+
+	topicNames := make([]string, len(topics))
+	for i, topic := range topics {
+		topicNames[i] = string(topic)
+	}
+	responses, err := c.m.client.CreateTopics(
+		ctx,
+		int32(c.partitionCount),
+		-1, // default.replication.factor
+		c.topicConfigs,
+		topicNames...,
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "CreateTopics returned an error")
+		return fmt.Errorf("failed to create kafka topics: %w", err)
+	}
+	createTopicParamsFields := []zap.Field{
+		zap.Int("partition_count", c.partitionCount),
+	}
+	if c.origTopicConfigs != nil {
+		createTopicParamsFields = append(createTopicParamsFields,
+			zap.Reflect("topic_configs", c.origTopicConfigs),
+		)
+	}
+	var createErrors []error
+	for _, response := range responses.Sorted() {
+		logger := c.m.cfg.Logger.With(zap.String("topic", response.Topic))
+		if err := response.Err; err != nil {
+			if errors.Is(err, kerr.TopicAlreadyExists) {
+				logger.Debug("kafka topic already exists")
+			} else {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "failed to create one or more topic")
+				createErrors = append(createErrors,
+					fmt.Errorf(
+						"failed to create topic %q: %w",
+						response.Topic, err,
+					),
+				)
+			}
+			continue
+		}
+		logger.Info("created kafka topic", createTopicParamsFields...)
+	}
+	return errors.Join(createErrors...)
+}

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -124,7 +124,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		logger := c.m.cfg.Logger.With(zap.String("topic", response.Topic))
 		if err := response.Err; err != nil {
 			if errors.Is(err, kerr.TopicAlreadyExists) {
-				logger.Debug("kafka topic already exists")
+				span.AddEvent("kafka topic already exists")
 			} else {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, "failed to create one or more topic")

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -108,7 +108,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 	)
 	if err != nil {
 		span.RecordError(err)
-		span.SetStatus(codes.Error, "CreateTopics returned an error")
+		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("failed to create kafka topics: %w", err)
 	}
 	createTopicParamsFields := []zap.Field{

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -124,7 +124,9 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		logger := c.m.cfg.Logger.With(zap.String("topic", response.Topic))
 		if err := response.Err; err != nil {
 			if errors.Is(err, kerr.TopicAlreadyExists) {
-				span.AddEvent("kafka topic already exists")
+				span.AddEvent("kafka topic already exists", trace.WithAttributes(
+					semconv.MessagingDestinationKey.String(response.Topic),
+				))
 			} else {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, "failed to create one or more topic")

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -134,6 +134,14 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	matchingLogs := observedLogs.FilterFieldKey("topic")
 	assert.Equal(t, []observer.LoggedEntry{{
 		Entry: zapcore.Entry{
+			Level:   zapcore.DebugLevel,
+			Message: "kafka topic already exists",
+		},
+		Context: []zapcore.Field{
+			zap.String("topic", "topic1"),
+		},
+	}, {
+		Entry: zapcore.Entry{
 			Level:   zapcore.InfoLevel,
 			Message: "created kafka topic",
 		},

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
-	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -37,16 +36,24 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-func TestNewManager(t *testing.T) {
-	_, err := NewManager(ManagerConfig{})
+func TestNewTopicCreator(t *testing.T) {
+	m, err := NewManager(ManagerConfig{
+		CommonConfig: CommonConfig{
+			Brokers: []string{"broker"},
+			Logger:  zap.NewNop(),
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { m.Close() })
+
+	_, err = m.NewTopicCreator(TopicCreatorConfig{})
 	assert.Error(t, err)
-	assert.EqualError(t, err, "kafka: invalid manager config: "+strings.Join([]string{
-		"kafka: at least one broker must be set",
-		"kafka: logger must be set",
+	assert.EqualError(t, err, "kafka: invalid topic creator config: "+strings.Join([]string{
+		"kafka: partition count must be non-zero",
 	}, "\n"))
 }
 
-func TestManagerDeleteTopics(t *testing.T) {
+func TestTopicCreatorCreateTopics(t *testing.T) {
 	exp := tracetest.NewInMemoryExporter()
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSyncer(exp),
@@ -57,50 +64,78 @@ func TestManagerDeleteTopics(t *testing.T) {
 	core, observedLogs := observer.New(zapcore.DebugLevel)
 	commonConfig.Logger = zap.New(core)
 	commonConfig.TracerProvider = tp
-	m, err := NewManager(ManagerConfig{CommonConfig: commonConfig})
+
+	m, err := NewManager(ManagerConfig{
+		CommonConfig: commonConfig,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() { m.Close() })
+	c, err := m.NewTopicCreator(TopicCreatorConfig{
+		PartitionCount: 123,
+		TopicConfigs: map[string]string{
+			"retention.ms": "123",
+		},
+	})
+	require.NoError(t, err)
 
-	var deleteTopicsRequest *kmsg.DeleteTopicsRequest
-	cluster.ControlKey(kmsg.DeleteTopics.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
-		deleteTopicsRequest = req.(*kmsg.DeleteTopicsRequest)
-		return &kmsg.DeleteTopicsResponse{
+	var createTopicsRequest *kmsg.CreateTopicsRequest
+	cluster.ControlKey(kmsg.CreateTopics.Int16(), func(req kmsg.Request) (kmsg.Response, error, bool) {
+		createTopicsRequest = req.(*kmsg.CreateTopicsRequest)
+		return &kmsg.CreateTopicsResponse{
 			Version: 7,
-			Topics: []kmsg.DeleteTopicsResponseTopic{{
-				Topic:        kmsg.StringPtr("topic1"),
-				ErrorCode:    kerr.UnknownTopicOrPartition.Code,
-				ErrorMessage: &kerr.UnknownTopicOrPartition.Message,
+			Topics: []kmsg.CreateTopicsResponseTopic{{
+				Topic:        "topic1",
+				ErrorCode:    kerr.TopicAlreadyExists.Code,
+				ErrorMessage: &kerr.TopicAlreadyExists.Message,
 			}, {
-				Topic:        kmsg.StringPtr("topic2"),
+				Topic:        "topic2",
 				ErrorCode:    kerr.InvalidTopicException.Code,
 				ErrorMessage: &kerr.InvalidTopicException.Message,
 			}, {
-				Topic:   kmsg.StringPtr("topic3"),
+				Topic:   "topic3",
 				TopicID: [16]byte{123},
 			}},
 		}, nil, true
 	})
-	err = m.DeleteTopics(context.Background(), "topic1", "topic2", "topic3")
+	err = c.CreateTopics(context.Background(), "topic1", "topic2", "topic3")
 	require.Error(t, err)
 	assert.EqualError(t, err,
-		`failed to delete topic "topic2": `+
+		`failed to create topic "topic2": `+
 			`INVALID_TOPIC_EXCEPTION: The request attempted to perform an operation on an invalid topic.`,
 	)
 
-	require.Len(t, deleteTopicsRequest.Topics, 3)
-	assert.Equal(t, []kmsg.DeleteTopicsRequestTopic{{
-		Topic: kmsg.StringPtr("topic1"),
+	require.Len(t, createTopicsRequest.Topics, 3)
+	assert.Equal(t, []kmsg.CreateTopicsRequestTopic{{
+		Topic:             "topic1",
+		NumPartitions:     123,
+		ReplicationFactor: -1,
+		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
+			Name:  "retention.ms",
+			Value: kmsg.StringPtr("123"),
+		}},
 	}, {
-		Topic: kmsg.StringPtr("topic2"),
+		Topic:             "topic2",
+		NumPartitions:     123,
+		ReplicationFactor: -1,
+		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
+			Name:  "retention.ms",
+			Value: kmsg.StringPtr("123"),
+		}},
 	}, {
-		Topic: kmsg.StringPtr("topic3"),
-	}}, deleteTopicsRequest.Topics)
+		Topic:             "topic3",
+		NumPartitions:     123,
+		ReplicationFactor: -1,
+		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
+			Name:  "retention.ms",
+			Value: kmsg.StringPtr("123"),
+		}},
+	}}, createTopicsRequest.Topics)
 
 	matchingLogs := observedLogs.FilterFieldKey("topic")
 	assert.Equal(t, []observer.LoggedEntry{{
 		Entry: zapcore.Entry{
 			Level:   zapcore.DebugLevel,
-			Message: "kafka topic does not exist",
+			Message: "kafka topic already exists",
 		},
 		Context: []zapcore.Field{
 			zap.String("topic", "topic1"),
@@ -108,16 +143,20 @@ func TestManagerDeleteTopics(t *testing.T) {
 	}, {
 		Entry: zapcore.Entry{
 			Level:   zapcore.InfoLevel,
-			Message: "deleted kafka topic",
+			Message: "created kafka topic",
 		},
 		Context: []zapcore.Field{
 			zap.String("topic", "topic3"),
+			zap.Int("partition_count", 123),
+			zap.Any("topic_configs", map[string]string{
+				"retention.ms": "123",
+			}),
 		},
 	}}, matchingLogs.AllUntimed())
 
 	spans := exp.GetSpans()
 	require.Len(t, spans, 1)
-	assert.Equal(t, "DeleteTopics", spans[0].Name)
+	assert.Equal(t, "CreateTopics", spans[0].Name)
 	assert.Equal(t, codes.Error, spans[0].Status.Code)
 	require.Len(t, spans[0].Events, 1)
 	assert.Equal(t, "exception", spans[0].Events[0].Name)
@@ -127,14 +166,4 @@ func TestManagerDeleteTopics(t *testing.T) {
 			"INVALID_TOPIC_EXCEPTION: The request attempted to perform an operation on an invalid topic.",
 		),
 	}, spans[0].Events[0].Attributes)
-}
-
-func newFakeCluster(t testing.TB) (*kfake.Cluster, CommonConfig) {
-	cluster, err := kfake.NewCluster()
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
-	return cluster, CommonConfig{
-		Brokers: cluster.ListenAddrs(),
-		Logger:  zap.NewNop(),
-	}
 }


### PR DESCRIPTION
This allows one to use a single Manager to create topics with differing partition counts and configs. It also enables one to create a Manager without specifying PartitionCount, e.g. in case one just wants to list topics.