### PR TITLE
kafka(test): Update kfake builder with partitions

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -153,7 +153,7 @@ func TestConsumerInstrumentation(t *testing.T) {
 	event := model.APMEvent{Transaction: &model.Transaction{ID: "1"}}
 	codec := json.JSON{}
 	topics := []apmqueue.Topic{"topic"}
-	client, addrs := newClusterWithTopics(t, topics...)
+	client, addrs := newClusterWithTopics(t, 2, topics...)
 	processed := make(chan struct{})
 	cfg := ConsumerConfig{
 		CommonConfig: CommonConfig{
@@ -287,7 +287,7 @@ func TestConsumerDelivery(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			client, addrs := newClusterWithTopics(t, topics...)
+			client, addrs := newClusterWithTopics(t, 2, topics...)
 			baseLogger := zapTest(t)
 
 			var processed atomic.Int32
@@ -411,7 +411,7 @@ func TestConsumerGracefulShutdown(t *testing.T) {
 	// that ensures that when the first record is read and the consumer closed,
 	// the second record is read as well and not lost.
 	test := func(t testing.TB, dt apmqueue.DeliveryType) {
-		client, brokers := newClusterWithTopics(t, "topic")
+		client, brokers := newClusterWithTopics(t, 2, "topic")
 		var codec json.JSON
 		var processed atomic.Int32
 		var errored atomic.Int32
@@ -480,7 +480,7 @@ func TestConsumerGracefulShutdown(t *testing.T) {
 }
 
 func TestConsumerContextPropagation(t *testing.T) {
-	_, addrs := newClusterWithTopics(t, "topic")
+	_, addrs := newClusterWithTopics(t, 2, "topic")
 	commonCfg := CommonConfig{
 		Brokers: addrs,
 		Logger:  zap.NewNop(),
@@ -541,7 +541,7 @@ func TestMultipleConsumers(t *testing.T) {
 	event := model.APMEvent{Transaction: &model.Transaction{ID: "1"}}
 	codec := json.JSON{}
 	topics := []apmqueue.Topic{"topic"}
-	client, addrs := newClusterWithTopics(t, topics...)
+	client, addrs := newClusterWithTopics(t, 2, topics...)
 
 	var count atomic.Int32
 	cfg := ConsumerConfig{
@@ -588,7 +588,7 @@ func TestMultipleConsumerGroups(t *testing.T) {
 	event := model.APMEvent{Transaction: &model.Transaction{ID: "1"}}
 	codec := json.JSON{}
 	topics := []apmqueue.Topic{"topic"}
-	client, addrs := newClusterWithTopics(t, topics...)
+	client, addrs := newClusterWithTopics(t, 2, topics...)
 	cfg := ConsumerConfig{
 		CommonConfig: CommonConfig{
 			Brokers: addrs,
@@ -642,7 +642,7 @@ func TestMultipleConsumerGroups(t *testing.T) {
 
 func TestConsumerRunError(t *testing.T) {
 	newConsumer := func(t testing.TB, ready chan struct{}) (*Consumer, *kgo.Client) {
-		client, addr := newClusterWithTopics(t, "topic")
+		client, addr := newClusterWithTopics(t, 2, "topic")
 		consumer := newConsumer(t, ConsumerConfig{
 			CommonConfig: CommonConfig{
 				Brokers: addr,

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -352,7 +352,7 @@ func newClusterWithTopics(t testing.TB, partitions int32, topics ...apmqueue.Top
 	for _, t := range topics {
 		strTopic = append(strTopic, string(t))
 	}
-	_, err = kadmClient.CreateTopics(context.Background(), 2, 1, nil, strTopic...)
+	_, err = kadmClient.CreateTopics(context.Background(), partitions, 1, nil, strTopic...)
 	require.NoError(t, err)
 	return client, addrs
 }

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -110,7 +110,7 @@ func TestNewProducerBasic(t *testing.T) {
 	test := func(t *testing.T, sync bool) {
 		t.Run(fmt.Sprintf("sync_%t", sync), func(t *testing.T) {
 			topic := apmqueue.Topic("default-topic")
-			client, brokers := newClusterWithTopics(t, topic)
+			client, brokers := newClusterWithTopics(t, 1, topic)
 			codec := json.JSON{}
 			producer, err := NewProducer(ProducerConfig{
 				CommonConfig: CommonConfig{
@@ -220,7 +220,7 @@ func (s *stub) MarshalJSON() ([]byte, error) {
 
 func TestProducerGracefulShutdown(t *testing.T) {
 	test := func(t testing.TB, dt apmqueue.DeliveryType, syncProducer bool) {
-		_, brokers := newClusterWithTopics(t, "topic")
+		_, brokers := newClusterWithTopics(t, 1, "topic")
 		var codec json.JSON
 		var processed atomic.Int64
 		producer := newProducer(t, ProducerConfig{
@@ -311,7 +311,7 @@ func TestProducerGracefulShutdown(t *testing.T) {
 }
 
 func TestProducerConcurrentClose(t *testing.T) {
-	_, brokers := newClusterWithTopics(t, "topic")
+	_, brokers := newClusterWithTopics(t, 1, "topic")
 	producer := newProducer(t, ProducerConfig{
 		CommonConfig: CommonConfig{
 			Brokers: brokers,
@@ -334,7 +334,7 @@ func TestProducerConcurrentClose(t *testing.T) {
 	wg.Wait()
 }
 
-func newClusterWithTopics(t testing.TB, topics ...apmqueue.Topic) (*kgo.Client, []string) {
+func newClusterWithTopics(t testing.TB, partitions int32, topics ...apmqueue.Topic) (*kgo.Client, []string) {
 	t.Helper()
 	cluster, err := kfake.NewCluster()
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Add a new partitions artgument to the `newClusterWithTopics` helper.

## Related issues

So #181 can specify 1 partition and remove test flakiness.