### PR TITLE
Clean up resources in CI properly

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -61,6 +61,17 @@ jobs:
         env:
           GOOGLE_REGION: us-central1
           GOOGLE_PROJECT: ${{ steps.gcp-auth.outputs.project_id }}
-          KAFKA_NAMESPACE: apm-queue-system-test-gh-workflow-run-${{ github.run_id }}-${{ github.run_attempt }}
+          KAFKA_NAMESPACE: apm-queue-system-test-gh-workflow-run-${{ github.run_id }}
+          PUBSUBLITE_RESERVATION_PREFIX: systemtest-ci-${{ github.run_id }}
         run: |
-          go test -v -timeout=60m .
+          go test -v -timeout=60m
+      - name: Cleanup
+        if: always() # always run, in case the test step aborts
+        working-directory: systemtest
+        env:
+          GOOGLE_REGION: us-central1
+          GOOGLE_PROJECT: ${{ steps.gcp-auth.outputs.project_id }}
+          KAFKA_NAMESPACE: apm-queue-system-test-gh-workflow-run-${{ github.run_id }}
+          PUBSUBLITE_RESERVATION_PREFIX: systemtest-ci-${{ github.run_id }}
+        run: |
+          go test -v -timeout=60m -destroy-only

--- a/systemtest/infra.go
+++ b/systemtest/infra.go
@@ -18,37 +18,22 @@
 package systemtest
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
 	apmqueue "github.com/elastic/apm-queue"
 )
 
-var destroyMu sync.Mutex
-var destroyFuncs map[string]func()
+// ProvisionInfraFunc is a function returned by Init* functions for
+// provisioning infrastructure.
+type ProvisionInfraFunc func(context.Context) error
 
-// RegisterDestroy registers a cleanup or destroy function to be run after the
-// tests have been run.
-func RegisterDestroy(key string, f func()) {
-	destroyMu.Lock()
-	defer destroyMu.Unlock()
-	if destroyFuncs == nil {
-		destroyFuncs = make(map[string]func())
-	}
-	destroyFuncs[key] = f
-}
-
-// Destroy runs all the registered destroy hooks.
-func Destroy() {
-	destroyMu.Lock()
-	defer destroyMu.Unlock()
-	for _, f := range destroyFuncs {
-		f()
-	}
-}
+// DestroyInfraFunc is a function returned by Init* functions for
+// destroying infrastructure.
+type DestroyInfraFunc func(context.Context) error
 
 var persistentSuffix string
 

--- a/systemtest/infra_pubsublite.go
+++ b/systemtest/infra_pubsublite.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -42,28 +43,46 @@ var (
 	googleRegion  string
 	googleAccount string
 
-	pubsubliteManager      *pubsublite.Manager
-	pubsubliteTopicCreator *pubsublite.TopicCreator
+	pubsubliteReservationPrefix string
+	pubsubliteReservation       string
+	pubsubliteManager           *pubsublite.Manager
+	pubsubliteTopicCreator      *pubsublite.TopicCreator
 )
+
+// InitPubSubLite initialises Pub/Sub Lite configuration, and returns a pair
+// of functions for provisioning and destroying a Pub/Sub Lite throughput
+// reservation and associated resources.
+func InitPubSubLite() (ProvisionInfraFunc, DestroyInfraFunc, error) {
+	initGCloud()
+	if googleProject == "" {
+		return nil, nil, errors.New("could not determine Google Cloud project; gcloud not initialized")
+	}
+	if googleRegion == "" {
+		return nil, nil, errors.New("could not determine Google Cloud region; GOOGLE_REGION not set")
+	}
+	if googleAccount == "" {
+		return nil, nil, errors.New("could not determine Google Cloud account; gcloud not initialized")
+	}
+
+	pubsubliteReservationPrefix = os.Getenv("PUBSUBLITE_RESERVATION_PREFIX")
+	if pubsubliteReservationPrefix != "" {
+		// Allow CI to specify a prefix, so it can automatically and safely clean up.
+		logger().Infof("$PUBSUBLITE_RESERVATION_PREFIX set to %q", pubsubliteReservationPrefix)
+	} else {
+		pubsubliteReservationPrefix = "systemtest-" + sanitizePubSubSuffix(googleAccount) + "-"
+	}
+
+	pubsubliteReservation = pubsubliteReservationPrefix + persistentSuffix
+	logger().Infof(
+		"managing Pub/Sub Lite throughput reservation %q in project %q, region %q, account %q",
+		pubsubliteReservation, googleProject, googleRegion, googleAccount,
+	)
+	return ProvisionPubSubLite, DestroyPubSubLite, nil
+}
 
 // ProvisionPubSubLite provisions a Pub/Sub Lite throughput reservation
 // using configuration taken from `gcloud` and $GOOGLE_REGION.
 func ProvisionPubSubLite(ctx context.Context) error {
-	initGCloud()
-	if googleProject == "" {
-		return errors.New("could not determine Google Cloud project; gcloud not initialized")
-	}
-	if googleRegion == "" {
-		return errors.New("could not determine Google Cloud region; GOOGLE_REGION not set")
-	}
-	if googleAccount == "" {
-		return errors.New("could not determine Google Cloud account; gcloud not initialized")
-	}
-
-	logger().Infof(
-		"provisioning Pub/Sub Lite throughput reservation in project %q, region %q, account %q",
-		googleProject, googleRegion, googleAccount,
-	)
 	manager, err := pubsublite.NewManager(pubsublite.ManagerConfig{
 		CommonConfig: PubSubLiteCommonConfig(),
 	})
@@ -74,17 +93,8 @@ func ProvisionPubSubLite(ctx context.Context) error {
 
 	// Delete any existing reservations with the matching prefix, and their associated
 	// topics and subscriptions.
-	resourcePrefix := "systemtest-" + sanitizePubSubSuffix(googleAccount) + "-"
-	reservationName := resourcePrefix + persistentSuffix
-	RegisterDestroy("pubsublite", func() {
-		defer manager.Close()
-		if err := destroyPubsubResources(context.Background(), manager, resourcePrefix); err != nil {
-			logger().Errorf("failed to destroy pubsublite resources: %w", err)
-			return
-		}
-	})
 	creator, err := pubsubliteManager.NewTopicCreator(pubsublite.TopicCreatorConfig{
-		Reservation:                reservationName,
+		Reservation:                pubsubliteReservation,
 		PartitionCount:             1,
 		PublishCapacityMiBPerSec:   4,
 		SubscribeCapacityMiBPerSec: 4,
@@ -100,10 +110,23 @@ func ProvisionPubSubLite(ctx context.Context) error {
 	// reservation name for the process's lifetime, since resource names cannot
 	// be reused within an hour of being destroyed.
 	const throughputCapacity = 2
-	if err := manager.CreateReservation(ctx, reservationName, throughputCapacity); err != nil {
+	if err := manager.CreateReservation(ctx, pubsubliteReservation, throughputCapacity); err != nil {
 		return err
 	}
-	logger().Info("Pub/Sub Lite infastructure fully provisioned!")
+	return nil
+}
+
+func DestroyPubSubLite(ctx context.Context) error {
+	manager, err := pubsublite.NewManager(pubsublite.ManagerConfig{
+		CommonConfig: PubSubLiteCommonConfig(),
+	})
+	if err != nil {
+		return err
+	}
+	defer manager.Close()
+	if err := destroyPubsubResources(ctx, manager, pubsubliteReservationPrefix); err != nil {
+		return fmt.Errorf("failed to destroy pubsublite resources: %w", err)
+	}
 	return nil
 }
 
@@ -145,16 +168,14 @@ func CreatePubsubTopics(ctx context.Context, t testing.TB, topics ...apmqueue.To
 	}
 }
 
-func destroyPubsubResources(ctx context.Context, manager *pubsublite.Manager, resourcePrefix string) error {
+func destroyPubsubResources(ctx context.Context, manager *pubsublite.Manager, reservationPrefix string) error {
 	var g errgroup.Group
 	reservations, err := manager.ListReservations(ctx)
 	if err != nil {
 		return err
 	}
 	for _, reservation := range reservations {
-		if !strings.HasPrefix(reservation, resourcePrefix) {
-			// We assume all topics and subscriptions associated with the
-			// reservation match the prefix and should be deleted.
+		if !strings.HasPrefix(reservation, reservationPrefix) {
 			continue
 		}
 		reservation := reservation // copy for closure


### PR DESCRIPTION
Ensure the Pub/Sub Lite reservation name's prefix
is scoped to the GitHub Actions job ID in CI, so
two unrelated PRs/jobs don't clobber each other's
infrastructure.

Update the Kafka namespace used in CI to remain
consistent for re-runs of a job, so we don't
accumulate namespaces.

Add a -destroy-only flag and call it in a CI step
that always runs, to ensure provisioned resources
are always destroyed at the end of a workflow.

Closes https://github.com/elastic/apm-queue/issues/169