### PR TITLE
systemtest: Only show logs on test failure

### DIFF
--- a/systemtest/infra_pubsublite.go
+++ b/systemtest/infra_pubsublite.go
@@ -65,7 +65,9 @@ func ProvisionPubSubLite(ctx context.Context) error {
 		googleProject, googleRegion, googleAccount,
 	)
 	manager, err := pubsublite.NewManager(pubsublite.ManagerConfig{
-		CommonConfig: PubSubLiteCommonConfig(),
+		CommonConfig: PubSubLiteCommonConfig(pubsublite.CommonConfig{
+			Logger: logger().Desugar().Named("pubsublite"),
+		}),
 	})
 	if err != nil {
 		return err
@@ -109,12 +111,10 @@ func ProvisionPubSubLite(ctx context.Context) error {
 
 // PubSubLiteCommonConfig returns a pubsublite.CommonConfig suitable for
 // using to construct pubsublite resources.
-func PubSubLiteCommonConfig() pubsublite.CommonConfig {
-	return pubsublite.CommonConfig{
-		Project: googleProject,
-		Region:  googleRegion,
-		Logger:  logger().Desugar(),
-	}
+func PubSubLiteCommonConfig(cfg pubsublite.CommonConfig) pubsublite.CommonConfig {
+	cfg.Project = googleProject
+	cfg.Region = googleRegion
+	return cfg
 }
 
 // CreatePubsubTopics interacts with the Google Cloud API to create

--- a/systemtest/main_test.go
+++ b/systemtest/main_test.go
@@ -29,8 +29,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var skipKafka, skipPubsublite bool
-
 func testMain(m *testing.M) int {
 	var skipDestroy bool
 	flag.BoolVar(&skipDestroy, "skip-destroy", false, "do not destroy the provisioned infrastructure after the tests finish")

--- a/systemtest/produce_consume_basic_test.go
+++ b/systemtest/produce_consume_basic_test.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 
 	"github.com/elastic/apm-data/model"
 	apmqueue "github.com/elastic/apm-queue"
@@ -50,9 +49,6 @@ func TestProduceConsumeSingleTopic(t *testing.T) {
 			producer, consumer := pf(t,
 				withProcessor(processor),
 				withSync(isSync),
-				withLogger(func(t testing.TB) *zap.Logger {
-					return NoLevelLogger(t, zap.ErrorLevel)
-				}),
 			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -88,9 +84,6 @@ func TestProduceConsumeMultipleTopics(t *testing.T) {
 			producer, consumer := pf(t,
 				withProcessor(processor),
 				withSync(isSync),
-				withLogger(func(t testing.TB) *zap.Logger {
-					return NoLevelLogger(t, zap.ErrorLevel)
-				}),
 				withTopicsGenerator(func(t testing.TB) []apmqueue.Topic {
 					return SuffixTopics(
 						apmqueue.Topic(t.Name()+"Even"),
@@ -102,7 +95,6 @@ func TestProduceConsumeMultipleTopics(t *testing.T) {
 							return topics[0]
 						}
 						return topics[1]
-
 					}
 				}),
 			)

--- a/systemtest/producer_consumer.go
+++ b/systemtest/producer_consumer.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newKafkaProducer(t testing.TB, cfg kafka.ProducerConfig) *kafka.Producer {
-	cfg.CommonConfig = KafkaCommonConfig(t)
+	cfg.CommonConfig = KafkaCommonConfig(t, cfg.CommonConfig)
 	producer, err := kafka.NewProducer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -40,7 +40,7 @@ func newKafkaProducer(t testing.TB, cfg kafka.ProducerConfig) *kafka.Producer {
 }
 
 func newPubSubLiteProducer(t testing.TB, cfg pubsublite.ProducerConfig) *pubsublite.Producer {
-	cfg.CommonConfig = PubSubLiteCommonConfig()
+	cfg.CommonConfig = PubSubLiteCommonConfig(cfg.CommonConfig)
 	producer, err := pubsublite.NewProducer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -51,7 +51,7 @@ func newPubSubLiteProducer(t testing.TB, cfg pubsublite.ProducerConfig) *pubsubl
 }
 
 func newKafkaConsumer(t testing.TB, cfg kafka.ConsumerConfig) *kafka.Consumer {
-	cfg.CommonConfig = KafkaCommonConfig(t)
+	cfg.CommonConfig = KafkaCommonConfig(t, cfg.CommonConfig)
 	consumer, err := kafka.NewConsumer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -62,7 +62,7 @@ func newKafkaConsumer(t testing.TB, cfg kafka.ConsumerConfig) *kafka.Consumer {
 }
 
 func newPubSubLiteConsumer(ctx context.Context, t testing.TB, cfg pubsublite.ConsumerConfig) *pubsublite.Consumer {
-	cfg.CommonConfig = PubSubLiteCommonConfig()
+	cfg.CommonConfig = PubSubLiteCommonConfig(cfg.CommonConfig)
 	consumer, err := pubsublite.NewConsumer(ctx, cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
Consolidates the loggers and creates a new logger that only prints the logs if the log has failed. This reduces the verbosity of the systemtest when run with the `-v` flag.

Also fixes the logger passed down to the created consumer/producer.

Closes #188