### PR TITLE
Remove apmqueue.Subscription

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -152,7 +152,7 @@ func (m *Manager) gatherMetrics(ctx context.Context, o metric.Observer) error {
 
 	// Fetch commits for consumer groups.
 	//
-	// TODO(axw) pass in apmqueue.Subscriptions, map these to consumer group names?
+	// TODO(axw) pass in a list of group names?
 	groups, err := m.adminClient.DescribeGroups(ctx)
 	if err != nil {
 		span.RecordError(err)

--- a/pubsublite/common.go
+++ b/pubsublite/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 
+	apmqueue "github.com/elastic/apm-queue"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -117,3 +118,9 @@ func (cfg *CommonConfig) tracerProvider() trace.TracerProvider {
 }
 
 // TODO(axw) method for producing common option.ClientOptions, such as otelgrpc interceptors.
+
+// SubscriptionName returns a Pub/Sub Lite subscription name
+// for the given topic and consumer name.
+func SubscriptionName(topic apmqueue.Topic, consumer string) string {
+	return fmt.Sprintf("%s+%s", topic, consumer)
+}

--- a/pubsublite/common.go
+++ b/pubsublite/common.go
@@ -23,11 +23,12 @@ import (
 	"fmt"
 	"os"
 
-	apmqueue "github.com/elastic/apm-queue"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/api/option"
+
+	apmqueue "github.com/elastic/apm-queue"
 )
 
 // CommonConfig defines common configuration for Kafka consumers, producers,

--- a/pubsublite/consumer_test.go
+++ b/pubsublite/consumer_test.go
@@ -36,7 +36,8 @@ func TestNewConsumer(t *testing.T) {
 			"pubsublite: project must be set",
 			"pubsublite: region must be set",
 			"pubsublite: logger must be set",
-			"pubsublite: at least one subscription must be set",
+			"pubsublite: at least one topic must be set",
+			"pubsublite: consumer name must be set",
 			"pubsublite: decoder must be set",
 			"pubsublite: processor must be set",
 		}, "\n"))
@@ -51,11 +52,10 @@ func TestNewConsumer(t *testing.T) {
 				Region:  "region_name",
 				Logger:  zap.NewNop(),
 			},
-			Decoder:   validDecoder,
-			Processor: validProcessor,
-			Subscriptions: []apmqueue.Subscription{
-				{Name: "subscription_name", Topic: "topic_name"},
-			},
+			Decoder:      validDecoder,
+			Processor:    validProcessor,
+			Topics:       []apmqueue.Topic{"topic_name"},
+			ConsumerName: "consumer_name",
 		}
 	}
 
@@ -65,19 +65,5 @@ func TestNewConsumer(t *testing.T) {
 		_, err := NewConsumer(context.Background(), config)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "pubsublite: invalid consumer config: pubsublite: delivery is not valid")
-	})
-
-	t.Run("invalid subscription", func(t *testing.T) {
-		config := validConfig()
-		config.Subscriptions = []apmqueue.Subscription{
-			{Name: "just_name_no_topic"},
-			{Topic: "just_topic_no_name"},
-		}
-		_, err := NewConsumer(context.Background(), config)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "pubsublite: invalid consumer config: "+strings.Join([]string{
-			"pubsublite: subscription topic must be set",
-			"pubsublite: subscription name must be set",
-		}, "\n"))
 	})
 }

--- a/queue.go
+++ b/queue.go
@@ -66,16 +66,6 @@ type Producer interface {
 	Close() error
 }
 
-// Subscription represents a topic subscription. This is roughly
-// equivalent to a Kafka topic consumer group.
-type Subscription struct {
-	// Name holds the name of the subscription.
-	Name string
-
-	// Topic holds the name of the subscribed topic.
-	Topic Topic
-}
-
 // Topic represents a destination topic where to produce a message/record.
 type Topic string
 

--- a/systemtest/infra.go
+++ b/systemtest/infra.go
@@ -80,16 +80,3 @@ func SuffixTopics(topics ...apmqueue.Topic) []apmqueue.Topic {
 	}
 	return suffixed
 }
-
-// SingleSubscribers returns a single apmqueue.Subscription for each
-// topic, with the subscriber having the same name as the topic.
-func SingleSubscribers(topics ...apmqueue.Topic) []apmqueue.Subscription {
-	out := make([]apmqueue.Subscription, len(topics))
-	for i, topic := range topics {
-		out[i] = apmqueue.Subscription{
-			Name:  string(topic),
-			Topic: topic,
-		}
-	}
-	return out
-}

--- a/systemtest/infra_pubsublite.go
+++ b/systemtest/infra_pubsublite.go
@@ -118,11 +118,7 @@ func PubSubLiteCommonConfig(cfg pubsublite.CommonConfig) pubsublite.CommonConfig
 }
 
 // CreatePubsubTopics interacts with the Google Cloud API to create
-// Pub/Sub Lite topics and subscriptions.
-//
-// TODO(axw) decouple creation of subscriptions from creation of topics.
-// Tests should be able to create multiple subscriptions for a topic,
-// or none.
+// Pub/Sub Lite topics.
 func CreatePubsubTopics(ctx context.Context, t testing.TB, topics ...apmqueue.Topic) {
 	err := pubsubliteTopicCreator.CreateTopics(ctx, topics...)
 	require.NoError(t, err)
@@ -133,13 +129,17 @@ func CreatePubsubTopics(ctx context.Context, t testing.TB, topics ...apmqueue.To
 			require.NoError(t, err)
 		})
 	}
+}
 
+// CreatePubsubTopicSubscriptions interacts with the Google Cloud API to create
+// Pub/Sub Lite subscriptions.
+func CreatePubsubTopicSubscriptions(ctx context.Context, t testing.TB, consumer string, topics ...apmqueue.Topic) {
 	for _, topic := range topics {
-		topic := string(topic)
-		err := pubsubliteManager.CreateSubscription(ctx, topic, topic, true)
+		subscriptionName := pubsublite.SubscriptionName(topic, consumer)
+		err := pubsubliteManager.CreateSubscription(ctx, subscriptionName, string(topic), true)
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			err := pubsubliteManager.DeleteSubscription(context.Background(), topic)
+			err := pubsubliteManager.DeleteSubscription(context.Background(), subscriptionName)
 			require.NoError(t, err)
 		})
 	}

--- a/systemtest/providers.go
+++ b/systemtest/providers.go
@@ -149,14 +149,9 @@ func pubSubTypes(t testing.TB, opts ...option) (apmqueue.Producer, apmqueue.Cons
 
 	logger := cfg.loggerF(t)
 	topics, topicRouter := cfg.topicsF(t)
-	subscriptions := make([]apmqueue.Subscription, len(topics))
-	for i, topic := range topics {
-		subscriptions[i] = apmqueue.Subscription{
-			Name:  string(topic),
-			Topic: topic,
-		}
-	}
+	consumerName := "test_consumer"
 	CreatePubsubTopics(ctx, t, topics...)
+	CreatePubsubTopicSubscriptions(ctx, t, consumerName, topics...)
 
 	producer := newPubSubLiteProducer(t, pubsublite.ProducerConfig{
 		CommonConfig: pubsublite.CommonConfig{Logger: logger.Named("producer")},
@@ -165,11 +160,12 @@ func pubSubTypes(t testing.TB, opts ...option) (apmqueue.Producer, apmqueue.Cons
 		Sync:         cfg.sync,
 	})
 	consumer := newPubSubLiteConsumer(context.Background(), t, pubsublite.ConsumerConfig{
-		CommonConfig:  pubsublite.CommonConfig{Logger: logger.Named("consumer")},
-		Decoder:       cfg.codec,
-		Subscriptions: subscriptions,
-		Processor:     cfg.processor,
-		Delivery:      cfg.dt,
+		CommonConfig: pubsublite.CommonConfig{Logger: logger.Named("consumer")},
+		Decoder:      cfg.codec,
+		Topics:       topics,
+		ConsumerName: consumerName,
+		Processor:    cfg.processor,
+		Delivery:     cfg.dt,
 	})
 	return producer, consumer
 }


### PR DESCRIPTION
Remove the apmqueue.Subscription type. This type never really made sense for Kafka, since you configure the consumer group ID on the client and then consume multile topics by name. Instead, we derive the Pub/Sub Lite subscription name from a topic and consumer name (similar to consumer group ID).