### PR TITLE
pubsublite(publisher): Record metrics, add testing

### DIFF
--- a/pubsublite/common.go
+++ b/pubsublite/common.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/api/option"
@@ -55,6 +56,10 @@ type CommonConfig struct {
 	// TracerProvider allows specifying a custom otel tracer provider.
 	// Defaults to the global one.
 	TracerProvider trace.TracerProvider
+
+	// MeterProvider allows specifying a custom otel meter provider.
+	// Defaults to the global one.
+	MeterProvider metric.MeterProvider
 }
 
 // Validate ensures the configuration is valid, otherwise, returns an error.
@@ -116,6 +121,13 @@ func (cfg *CommonConfig) tracerProvider() trace.TracerProvider {
 		return cfg.TracerProvider
 	}
 	return otel.GetTracerProvider()
+}
+
+func (cfg *CommonConfig) meterProvider() metric.MeterProvider {
+	if cfg.MeterProvider != nil {
+		return cfg.MeterProvider
+	}
+	return otel.GetMeterProvider()
 }
 
 // TODO(axw) method for producing common option.ClientOptions, such as otelgrpc interceptors.

--- a/pubsublite/internal/pubsubabs/publisher.go
+++ b/pubsublite/internal/pubsubabs/publisher.go
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package pubsubabs provides an abstraction layer over the `pubsub`
+// PublisherClient types to allow testing.
+package pubsubabs
+
+import (
+	"context"
+
+	"cloud.google.com/go/pubsub"
+)
+
+// ErrorStop defines the Stop and Error methods.
+type ErrorStop interface {
+	// Stop sends all remaining published messages and closes publish streams.
+	// Returns once all outstanding messages have been sent or have failed to be
+	// sent. Stop should be called when the client is no longer required.
+	Error() error
+	// Error returns the error that caused the publisher client to terminate. The
+	// error returned here may contain more context than PublishResult errors. The
+	// return value may be nil if Stop() was called.
+	Stop()
+}
+
+// PublisherClient represents a PubSub PublisherClient.
+type PublisherClient interface {
+	ErrorStop
+	Publish(ctx context.Context, msg *pubsub.Message) *pubsub.PublishResult
+}
+
+// Publisher defines an abstracted interface that can be used for mocking or
+// testing purposes. It wraps a Publisher client.
+type Publisher interface {
+	ErrorStop
+	// Publish publishes `msg` to the topic asynchronously. Messages are batched and
+	// sent according to the client's PublishSettings. Publish never blocks.
+	//
+	// Publish returns a non-nil PublishResult which will be ready when the
+	// message has been sent (or has failed to be sent) to the server. Retry-able
+	// errors are automatically handled. If a PublishResult returns an error, this
+	// indicates that the publisher client encountered a fatal error and can no
+	// longer be used. Fatal errors should be manually inspected and the cause
+	// resolved. A new publisher client instance must be created to republish failed
+	// messages.
+	//
+	// Once Stop() has been called or the publisher client has failed permanently
+	// due to an error, future calls to Publish will immediately return a
+	// PublishResult with error ErrPublisherStopped.
+	//
+	// Error() returns the error that caused the publisher client to terminate and
+	// may contain more context than the error returned by PublishResult.
+	Publish(ctx context.Context, msg *pubsub.Message) PublishResult
+}
+
+// Wrap returns an abstracted Publisher from a PublisherClient.
+func Wrap(c PublisherClient) Publisher { return &pubSubClient{c} }
+
+type pubSubClient struct {
+	PublisherClient
+}
+
+func (p *pubSubClient) Publish(ctx context.Context, msg *pubsub.Message) PublishResult {
+	return p.PublisherClient.Publish(ctx, msg)
+}
+
+// PublishResult abstracts the pubsub.PublishResult type.
+type PublishResult interface {
+	// Ready returns a channel that is closed when the result is ready.
+	// When the Ready channel is closed, Get is guaranteed not to block.
+	Get(ctx context.Context) (serverID string, err error)
+	// Get returns the server-generated message ID and/or error result of a Publish call.
+	// Get blocks until the Publish call completes or the context is done.
+	Ready() <-chan struct{}
+}
+
+// IPublishResult is a copy from the internal pubsub packgage. All the code
+// below has been copied from "cloud.google.com/go/internal/pubsub"
+// Copyright 2020 Google LLC
+type IPublishResult struct {
+	err      error
+	ready    chan struct{}
+	serverID string
+}
+
+// Ready returns a channel that is closed when the result is ready.
+// When the Ready channel is closed, Get is guaranteed not to block.
+func (r *IPublishResult) Ready() <-chan struct{} { return r.ready }
+
+// Get returns the server-generated message ID and/or error result of a Publish call.
+// Get blocks until the Publish call completes or the context is done.
+func (r *IPublishResult) Get(ctx context.Context) (serverID string, err error) {
+	// If the result is already ready, return it even if the context is done.
+	select {
+	case <-r.Ready():
+		return r.serverID, r.err
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-r.Ready():
+		return r.serverID, r.err
+	}
+}
+
+// NewPublishResult creates a PublishResult.
+func NewPublishResult() *IPublishResult {
+	return &IPublishResult{ready: make(chan struct{})}
+}
+
+// SetPublishResult sets the server ID and error for a publish result and closes
+// the Ready channel.
+func SetPublishResult(r *IPublishResult, sid string, err error) {
+	r.serverID = sid
+	r.err = err
+	close(r.ready)
+}

--- a/pubsublite/internal/pubsubabs/publisher.go
+++ b/pubsublite/internal/pubsubabs/publisher.go
@@ -27,13 +27,13 @@ import (
 
 // ErrorStop defines the Stop and Error methods.
 type ErrorStop interface {
-	// Stop sends all remaining published messages and closes publish streams.
-	// Returns once all outstanding messages have been sent or have failed to be
-	// sent. Stop should be called when the client is no longer required.
-	Error() error
 	// Error returns the error that caused the publisher client to terminate. The
 	// error returned here may contain more context than PublishResult errors. The
 	// return value may be nil if Stop() was called.
+	Error() error
+	// Stop sends all remaining published messages and closes publish streams.
+	// Returns once all outstanding messages have been sent or have failed to be
+	// sent. Stop should be called when the client is no longer required.
 	Stop()
 }
 
@@ -80,11 +80,11 @@ func (p *pubSubClient) Publish(ctx context.Context, msg *pubsub.Message) Publish
 
 // PublishResult abstracts the pubsub.PublishResult type.
 type PublishResult interface {
-	// Ready returns a channel that is closed when the result is ready.
-	// When the Ready channel is closed, Get is guaranteed not to block.
-	Get(ctx context.Context) (serverID string, err error)
 	// Get returns the server-generated message ID and/or error result of a Publish call.
 	// Get blocks until the Publish call completes or the context is done.
+	Get(ctx context.Context) (serverID string, err error)
+	// Ready returns a channel that is closed when the result is ready.
+	// When the Ready channel is closed, Get is guaranteed not to block.
 	Ready() <-chan struct{}
 }
 

--- a/pubsublite/internal/pubsubabs/publisher_test.go
+++ b/pubsublite/internal/pubsubabs/publisher_test.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package pubsubabs provides an abstraction layer over the `pubsub`
+// PublisherClient types to allow testing.
+package pubsubabs
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrap(t *testing.T) {
+	var publisher mockPublisher
+	wrapped := Wrap(&publisher)
+
+	assert.False(t, publisher.publishCalled)
+	assert.False(t, publisher.errorCalled)
+	assert.False(t, publisher.stopCalled)
+
+	assert.NoError(t, wrapped.Error())
+	assert.True(t, publisher.errorCalled)
+
+	wrapped.Stop()
+	assert.True(t, publisher.stopCalled)
+
+	assert.Equal(t,
+		wrapped.Publish(context.Background(), &pubsub.Message{}),
+		&pubsub.PublishResult{},
+	)
+	assert.True(t, publisher.publishCalled)
+}
+
+type mockPublisher struct {
+	errorCalled   bool
+	stopCalled    bool
+	publishCalled bool
+}
+
+// Error returns the producer stop error.
+func (p *mockPublisher) Error() error {
+	p.errorCalled = true
+	return nil
+}
+
+// Stop stops the producer.
+func (p *mockPublisher) Stop() {
+	p.stopCalled = true
+}
+
+// Publish wraps the pubsublite publish.
+func (p *mockPublisher) Publish(ctx context.Context, msg *pubsub.Message) *pubsub.PublishResult {
+	p.publishCalled = true
+	return &pubsub.PublishResult{}
+}

--- a/pubsublite/internal/telemetry/publisher.go
+++ b/pubsublite/internal/telemetry/publisher.go
@@ -40,21 +40,21 @@ const (
 	instrumentName = "github.com/elastic/apm-queue/pubsublite"
 )
 
-// ProducerMetrics hold the metrics that are recorded for producers
-type ProducerMetrics struct {
+// PublisherMetrics hold the metrics that are recorded for producers
+type PublisherMetrics struct {
 	produced metric.Int64Counter
 	errored  metric.Int64Counter
 }
 
-// NewProducerMetrics instantiates the producer metrics.
-func NewProducerMetrics(mp metric.MeterProvider) (ProducerMetrics, error) {
+// NewPublisherMetrics instantiates the producer metrics.
+func NewPublisherMetrics(mp metric.MeterProvider) (PublisherMetrics, error) {
 	m := mp.Meter(instrumentName)
 	produced, err := m.Int64Counter(producedKey,
 		metric.WithDescription("The number of messages produced"),
 		metric.WithUnit("1"),
 	)
 	if err != nil {
-		return ProducerMetrics{}, fmt.Errorf(
+		return PublisherMetrics{}, fmt.Errorf(
 			"telemetry: cannot create %s metric: %w", producedKey, err,
 		)
 	}
@@ -63,11 +63,11 @@ func NewProducerMetrics(mp metric.MeterProvider) (ProducerMetrics, error) {
 		metric.WithUnit("1"),
 	)
 	if err != nil {
-		return ProducerMetrics{}, fmt.Errorf(
+		return PublisherMetrics{}, fmt.Errorf(
 			"telemetry: cannot create %s metric: %w", erroredKey, err,
 		)
 	}
-	return ProducerMetrics{
+	return PublisherMetrics{
 		produced: produced,
 		errored:  errored,
 	}, nil
@@ -79,7 +79,7 @@ var _ pubsubabs.Publisher = &Producer{}
 type Producer struct {
 	client  pubsubabs.Publisher
 	tracer  trace.Tracer
-	metrics ProducerMetrics
+	metrics PublisherMetrics
 	attrs   []attribute.KeyValue
 }
 
@@ -135,7 +135,7 @@ func (p *Producer) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.P
 func NewProducer(
 	client pubsubabs.Publisher,
 	tracer trace.Tracer,
-	metrics ProducerMetrics,
+	metrics PublisherMetrics,
 	attrs []attribute.KeyValue,
 ) *Producer {
 	return &Producer{

--- a/pubsublite/internal/telemetry/publisher.go
+++ b/pubsublite/internal/telemetry/publisher.go
@@ -19,43 +19,89 @@ package telemetry
 
 import (
 	"context"
+	"fmt"
 
 	"cloud.google.com/go/pubsub"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/elastic/apm-queue/pubsublite/internal/pubsubabs"
 )
 
-type producerHandler = func(context.Context, *pubsub.Message) *pubsub.PublishResult
+const (
+	producedKey = "producer.messages.produced"
+	erroredKey  = "producer.messages.errored"
 
-// Publisher adds telemetry data to messages published
-func Publisher(ctx context.Context, tracer trace.Tracer, msg *pubsub.Message, h producerHandler, attrs []attribute.KeyValue) *pubsub.PublishResult {
+	instrumentName = "github.com/elastic/apm-queue/pubsublite"
+)
 
-	attrs = append(attrs,
-		semconv.MessagingSystemKey.String("pubsublite"),
-		semconv.MessagingDestinationKindTopic,
+// ProducerMetrics hold the metrics that are recorded for producers
+type ProducerMetrics struct {
+	produced metric.Int64Counter
+	errored  metric.Int64Counter
+}
+
+// NewProducerMetrics instantiates the producer metrics.
+func NewProducerMetrics(mp metric.MeterProvider) (ProducerMetrics, error) {
+	m := mp.Meter(instrumentName)
+	produced, err := m.Int64Counter(producedKey,
+		metric.WithDescription("The number of messages produced"),
+		metric.WithUnit("1"),
 	)
-	ctx, span := tracer.Start(ctx, "pubsublite.Publish",
-		trace.WithSpanKind(trace.SpanKindProducer),
-		trace.WithAttributes(attrs...),
-	)
-
-	if msg == nil {
-		msg = &pubsub.Message{}
+	if err != nil {
+		return ProducerMetrics{}, fmt.Errorf(
+			"telemetry: cannot create %s metric: %w", producedKey, err,
+		)
 	}
+	errored, err := m.Int64Counter(erroredKey,
+		metric.WithDescription("The number of messages that failed to be produced"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return ProducerMetrics{}, fmt.Errorf(
+			"telemetry: cannot create %s metric: %w", erroredKey, err,
+		)
+	}
+	return ProducerMetrics{
+		produced: produced,
+		errored:  errored,
+	}, nil
+}
 
+var _ pubsubabs.Publisher = &Producer{}
+
+// Producer wraps a publisher client to provider tracing and metering.
+type Producer struct {
+	client  pubsubabs.Publisher
+	tracer  trace.Tracer
+	metrics ProducerMetrics
+	attrs   []attribute.KeyValue
+}
+
+// Error returns the producer stop error.
+func (p *Producer) Error() error { return p.client.Error() }
+
+// Stop stops the producer.
+func (p *Producer) Stop() { p.client.Stop() }
+
+// Publish wraps the pubsublite publish action with traces and metrics.
+func (p *Producer) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.PublishResult {
+	ctx, span := p.tracer.Start(ctx, "pubsublite.Publish",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(p.attrs...),
+	)
 	if msg.Attributes == nil {
 		msg.Attributes = make(map[string]string)
 	}
 	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(msg.Attributes))
-
-	res := h(ctx, msg)
-
+	res := p.client.Publish(ctx, msg)
 	// This creates one goroutine for each message, which may cause overhead for
-	// mid-high producers.
+	// mid-high throughput producers.
 	// See also https://github.com/googleapis/google-cloud-go/issues/2953
 	go func() {
 		mid, err := res.Get(ctx)
@@ -63,10 +109,34 @@ func Publisher(ctx context.Context, tracer trace.Tracer, msg *pubsub.Message, h 
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
+			p.metrics.errored.Add(ctx, 1, metric.WithAttributes(
+				p.attrs...,
+			))
+		} else {
+			span.SetStatus(codes.Ok, "success")
+			p.metrics.produced.Add(ctx, 1, metric.WithAttributes(
+				p.attrs...,
+			))
 		}
-
 		span.End()
 	}()
-
 	return res
+}
+
+// NewProducer decorates an existing publisher with tracing and metering.
+func NewProducer(
+	client pubsubabs.Publisher,
+	tracer trace.Tracer,
+	metrics ProducerMetrics,
+	attrs []attribute.KeyValue,
+) *Producer {
+	return &Producer{
+		client:  client,
+		tracer:  tracer,
+		metrics: metrics,
+		attrs: append(attrs,
+			semconv.MessagingSystemKey.String("pubsublite"),
+			semconv.MessagingDestinationKindTopic,
+		),
+	}
 }

--- a/pubsublite/internal/telemetry/publisher.go
+++ b/pubsublite/internal/telemetry/publisher.go
@@ -94,6 +94,7 @@ func (p *Producer) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.P
 	attrs := p.attrs
 	if len(msg.Attributes) > 0 {
 		attrs = make([]attribute.KeyValue, 0, len(p.attrs)+len(msg.Attributes))
+		attrs = append(attrs, p.attrs...)
 		for key, v := range msg.Attributes {
 			attrs = append(attrs, attribute.String(key, v))
 		}

--- a/pubsublite/internal/telemetry/publisher_test.go
+++ b/pubsublite/internal/telemetry/publisher_test.go
@@ -19,17 +19,24 @@ package telemetry
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-queue/pubsublite/internal/pubsubabs"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
@@ -56,41 +63,13 @@ func TestPublisher(t *testing.T) {
 		resServerID string
 		resErr      error
 
+		success bool
+
 		expectedSpans tracetest.SpanStubs
+		expectMetrics metricdata.Metrics
 	}{
 		{
-			name: "with no message",
-
-			expectedSpans: tracetest.SpanStubs{
-				tracetest.SpanStub{
-					Name:     "pubsublite.Publish",
-					SpanKind: trace.SpanKindProducer,
-					Attributes: []attribute.KeyValue{
-						semconv.MessagingSystemKey.String("pubsublite"),
-						semconv.MessagingDestinationKindTopic,
-						semconv.MessagingMessageIDKey.String(""),
-					},
-					InstrumentationLibrary: instrumentation.Library{
-						Name: "test",
-					},
-					Events: []sdktrace.Event{
-						sdktrace.Event{
-							Name: "exception",
-							Attributes: []attribute.KeyValue{
-								attribute.String("exception.type", "*errors.errorString"),
-								attribute.String("exception.message", "context canceled"),
-							},
-						},
-					},
-					Status: sdktrace.Status{
-						Code:        codes.Error,
-						Description: "context canceled",
-					},
-				},
-			},
-		},
-		{
-			name: "with no attributes",
+			name: "failure with no attributes",
 			msg:  &pubsub.Message{},
 
 			expectedSpans: tracetest.SpanStubs{
@@ -100,29 +79,43 @@ func TestPublisher(t *testing.T) {
 					Attributes: []attribute.KeyValue{
 						semconv.MessagingSystemKey.String("pubsublite"),
 						semconv.MessagingDestinationKindTopic,
-						semconv.MessagingMessageIDKey.String(""),
+						semconv.MessagingMessageIDKey.String("msg-id"),
 					},
 					InstrumentationLibrary: instrumentation.Library{
 						Name: "test",
 					},
-					Events: []sdktrace.Event{
-						sdktrace.Event{
-							Name: "exception",
-							Attributes: []attribute.KeyValue{
-								attribute.String("exception.type", "*errors.errorString"),
-								attribute.String("exception.message", "context canceled"),
-							},
+					Events: []sdktrace.Event{{
+						Name: "exception",
+						Attributes: []attribute.KeyValue{
+							attribute.String("exception.type", "*errors.errorString"),
+							attribute.String("exception.message", "failed processing message"),
 						},
-					},
+					}},
 					Status: sdktrace.Status{
 						Code:        codes.Error,
-						Description: "context canceled",
+						Description: "failed processing message",
 					},
+				},
+			},
+			expectMetrics: metricdata.Metrics{
+				Name:        "producer.messages.errored",
+				Description: "The number of messages that failed to be produced",
+				Unit:        "1",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{{
+						Value: 1,
+						Attributes: attribute.NewSet(
+							semconv.MessagingSystemKey.String("pubsublite"),
+							semconv.MessagingDestinationKindTopic,
+						),
+					}},
 				},
 			},
 		},
 		{
-			name: "with otel attributes",
+			name: "success with otel attributes",
 			msg:  &pubsub.Message{},
 
 			attributes: []attribute.KeyValue{
@@ -137,37 +130,111 @@ func TestPublisher(t *testing.T) {
 						attribute.String("project", "project_name"),
 						semconv.MessagingSystemKey.String("pubsublite"),
 						semconv.MessagingDestinationKindTopic,
-						semconv.MessagingMessageIDKey.String(""),
+						semconv.MessagingMessageIDKey.String("msg-id"),
 					},
 					InstrumentationLibrary: instrumentation.Library{
 						Name: "test",
 					},
-					Events: []sdktrace.Event{
-						sdktrace.Event{
-							Name: "exception",
-							Attributes: []attribute.KeyValue{
-								attribute.String("exception.type", "*errors.errorString"),
-								attribute.String("exception.message", "context canceled"),
-							},
+					Events: []sdktrace.Event{{
+						Name: "exception",
+						Attributes: []attribute.KeyValue{
+							attribute.String("exception.type", "*errors.errorString"),
+							attribute.String("exception.message", "failed processing message"),
 						},
-					},
+					}},
 					Status: sdktrace.Status{
 						Code:        codes.Error,
-						Description: "context canceled",
+						Description: "failed processing message",
 					},
+				},
+			},
+			expectMetrics: metricdata.Metrics{
+				Name:        "producer.messages.errored",
+				Description: "The number of messages that failed to be produced",
+				Unit:        "1",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{{
+						Value: 1,
+						Attributes: attribute.NewSet(
+							semconv.MessagingSystemKey.String("pubsublite"),
+							semconv.MessagingDestinationKindTopic,
+							attribute.String("project", "project_name"),
+						),
+					}},
+				},
+			},
+		},
+		{
+			name: "success with otel attributes",
+			msg:  &pubsub.Message{},
+
+			attributes: []attribute.KeyValue{
+				attribute.String("project", "project_name"),
+			},
+			success: true, // succeed
+
+			expectedSpans: tracetest.SpanStubs{
+				tracetest.SpanStub{
+					Name:     "pubsublite.Publish",
+					SpanKind: trace.SpanKindProducer,
+					Attributes: []attribute.KeyValue{
+						attribute.String("project", "project_name"),
+						semconv.MessagingSystemKey.String("pubsublite"),
+						semconv.MessagingDestinationKindTopic,
+						semconv.MessagingMessageIDKey.String("msg-id"),
+					},
+					InstrumentationLibrary: instrumentation.Library{
+						Name: "test",
+					},
+					Status: sdktrace.Status{
+						Code: codes.Ok,
+					},
+				},
+			},
+			expectMetrics: metricdata.Metrics{
+				Name:        "producer.messages.produced",
+				Description: "The number of messages produced",
+				Unit:        "1",
+				Data: metricdata.Sum[int64]{
+					IsMonotonic: true,
+					Temporality: metricdata.CumulativeTemporality,
+					DataPoints: []metricdata.DataPoint[int64]{{
+						Value: 1,
+						Attributes: attribute.NewSet(
+							semconv.MessagingSystemKey.String("pubsublite"),
+							semconv.MessagingDestinationKindTopic,
+							attribute.String("project", "project_name"),
+						),
+					}},
 				},
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			res := &pubsub.PublishResult{}
+			rdr := sdkmetric.NewManualReader()
+			pm, err := NewProducerMetrics(sdkmetric.NewMeterProvider(
+				sdkmetric.WithReader(rdr),
+			))
+			require.NoError(t, err)
+
+			res := pubsubabs.NewPublishResult()
 			ctx, cancel := context.WithCancel(context.Background())
-			_ = Publisher(ctx, tp.Tracer("test"), tt.msg, func(ctx context.Context, msg *pubsub.Message) *pubsub.PublishResult {
+			defer cancel()
+			client := newPublisherFunc(func(ctx context.Context, msg *pubsub.Message) pubsubabs.PublishResult {
 				return res
-			}, tt.attributes)
+			})
+			producer := NewProducer(client, tp.Tracer("test"), pm, tt.attributes)
+			_ = producer.Publish(ctx, tt.msg)
+
+			if tt.success {
+				pubsubabs.SetPublishResult(res, "msg-id", nil)
+			} else {
+				pubsubabs.SetPublishResult(res, "msg-id", errors.New("failed processing message"))
+			}
 
 			// Wait for the async goroutine to finish runnning
-			cancel()
 			time.Sleep(time.Millisecond)
 
 			spans := exp.GetSpans()
@@ -192,8 +259,35 @@ func TestPublisher(t *testing.T) {
 
 			assert.Equal(t, tt.expectedSpans, spans)
 
+			// NOTE(marclop) for now, it is only possible to assert failures.
+			var rm metricdata.ResourceMetrics
+			assert.NoError(t, rdr.Collect(context.Background(), &rm))
+
+			assert.Len(t, rm.ScopeMetrics[0].Metrics, 1)
+			metricdatatest.AssertEqual(t,
+				tt.expectMetrics,
+				rm.ScopeMetrics[0].Metrics[0],
+				metricdatatest.IgnoreTimestamp(),
+			)
 			// Reset for next tests
 			exp.Reset()
 		})
 	}
+}
+
+type publishFunc func(ctx context.Context, msg *pubsub.Message) pubsubabs.PublishResult
+
+func newPublisherFunc(f publishFunc) pubsubabs.Publisher { return pfunc(f) }
+
+type pfunc publishFunc
+
+// Error returns the producer stop error.
+func (p pfunc) Error() error { return nil }
+
+// Stop stops the producer.
+func (p pfunc) Stop() {}
+
+// Publish wraps the pubsublite publish.
+func (p pfunc) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.PublishResult {
+	return p(ctx, msg)
 }

--- a/pubsublite/internal/telemetry/publisher_test.go
+++ b/pubsublite/internal/telemetry/publisher_test.go
@@ -168,7 +168,9 @@ func TestPublisher(t *testing.T) {
 		},
 		{
 			name: "success with otel attributes",
-			msg:  &pubsub.Message{},
+			msg: &pubsub.Message{
+				Attributes: map[string]string{"key": "value"},
+			},
 
 			attributes: []attribute.KeyValue{
 				attribute.String("project", "project_name"),
@@ -183,6 +185,7 @@ func TestPublisher(t *testing.T) {
 						attribute.String("project", "project_name"),
 						semconv.MessagingSystemKey.String("pubsublite"),
 						semconv.MessagingDestinationKindTopic,
+						attribute.String("key", "value"),
 						semconv.MessagingMessageIDKey.String("msg-id"),
 					},
 					InstrumentationLibrary: instrumentation.Library{
@@ -206,6 +209,7 @@ func TestPublisher(t *testing.T) {
 							semconv.MessagingSystemKey.String("pubsublite"),
 							semconv.MessagingDestinationKindTopic,
 							attribute.String("project", "project_name"),
+							attribute.String("key", "value"),
 						),
 					}},
 				},

--- a/pubsublite/internal/telemetry/publisher_test.go
+++ b/pubsublite/internal/telemetry/publisher_test.go
@@ -218,7 +218,7 @@ func TestPublisher(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			rdr := sdkmetric.NewManualReader()
-			pm, err := NewProducerMetrics(sdkmetric.NewMeterProvider(
+			pm, err := NewPublisherMetrics(sdkmetric.NewMeterProvider(
 				sdkmetric.WithReader(rdr),
 			))
 			require.NoError(t, err)

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -90,7 +90,7 @@ type Producer struct {
 	responses chan []resTopic
 	closed    chan struct{}
 	tracer    trace.Tracer
-	metrics   telemetry.ProducerMetrics
+	metrics   telemetry.PublisherMetrics
 }
 
 // NewProducer creates a new PubSub Lite producer for a single project.
@@ -101,7 +101,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("pubsublite: invalid producer config: %w", err)
 	}
-	metrics, err := telemetry.NewProducerMetrics(cfg.meterProvider())
+	metrics, err := telemetry.NewPublisherMetrics(cfg.meterProvider())
 	if err != nil {
 		return nil, fmt.Errorf("pubsublite: %w", err)
 	}


### PR DESCRIPTION
This PR is the counterpart of #181 for the pubsublite package, with a bit of refactoring that was needed in order to be able test the metrics.

Introduces a new package `pubsubabs` which provides the necessary means to abstract the types in the `pubsub` package. Two new interfaces are introduced; `PublisherClient` implements the `pubsub.PublisherClient`, and `Publisher`, which returns a `PublishResult` interface that can be used to assert that our business logic works as expected in unit tests.

This allows us to start writing unit tests for the pubsublite.Publisher.

`telemetry.Producer` now implements the `pubsubabs.Publisher` interface and has been refactored from a function to a type.

`producer.messages.produced` and `produced.messages.errored` metrics are now recorded and reported using the configured OTel meter provider.