### PR TITLE
ci: correctly pass github token to workflow

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -19,6 +19,8 @@ jobs:
       pull-requests: read
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/is-pr-approved@current
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
   run-system-tests:
     needs:
       - is-pr-approved


### PR DESCRIPTION
## What is the change being made?

* Properly pass github token to workflow

## Why is the change being made?

* The GitHub token wasn't validated until last week.
