### PR TITLE
kafka/consumer: Record `consumer.messages.fetched`

### DIFF
--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -33,62 +33,62 @@ const (
 
 	unitCount = "1"
 
-	messageProducedCounterKey = "producer.messages.produced"
-	messageErroredCounterKey  = "producer.messages.errored"
+	msgProducedKey = "producer.messages.produced"
+	msgErroredKey  = "producer.messages.errored"
+	msgFetchedKey  = "consumer.messages.fetched"
 )
 
 type metricHooks struct {
 	messageProduced metric.Int64Counter
 	messageErrored  metric.Int64Counter
+	messageFetched  metric.Int64Counter
 }
 
 func newKgoHooks(mp metric.MeterProvider) (*metricHooks, error) {
 	m := mp.Meter(instrumentName)
-
-	messageProducedCounter, err := m.Int64Counter(
-		messageProducedCounterKey,
+	messageProducedCounter, err := m.Int64Counter(msgProducedKey,
 		metric.WithDescription("The number of messages produced"),
 		metric.WithUnit(unitCount),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create %s metric: %w", messageProducedCounterKey, err)
+		return nil, formatMetricError(msgProducedKey, err)
 	}
-
-	messageErroredCounter, err := m.Int64Counter(
-		messageErroredCounterKey,
+	messageErroredCounter, err := m.Int64Counter(msgErroredKey,
 		metric.WithDescription("The number of messages that failed to be produced"),
 		metric.WithUnit(unitCount),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("cannot create %s metric: %w", messageErroredCounterKey, err)
+		return nil, formatMetricError(msgErroredKey, err)
 	}
-
+	messageFetchedCounter, err := m.Int64Counter(msgFetchedKey,
+		metric.WithDescription("The number of messages that were fetched from a kafka topic"),
+		metric.WithUnit(unitCount),
+	)
+	if err != nil {
+		return nil, formatMetricError(msgFetchedKey, err)
+	}
 	return &metricHooks{
+		// Producer
 		messageProduced: messageProducedCounter,
 		messageErrored:  messageErroredCounter,
+		// Consumer
+		messageFetched: messageFetchedCounter,
 	}, nil
 }
 
+func formatMetricError(name string, err error) error {
+	return fmt.Errorf("cannot create %s metric: %w", name, err)
+}
+
+// OnProduceRecordUnbuffered records the number of produced / failed messages.
 // https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookProduceRecordUnbuffered
 func (h *metricHooks) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
-	attrs := make([]attribute.KeyValue, 0, 5) // Preallocate 5 elements.
-	attrs = append(attrs,
-		semconv.MessagingDestinationName(r.Topic),
-		semconv.MessagingKafkaDestinationPartition(int(r.Partition)),
-	)
-	for _, v := range r.Headers {
-		if v.Key == "traceparent" { // Ignore traceparent header.
-			continue
-		}
-		attrs = append(attrs, attribute.String(v.Key, string(v.Value)))
-	}
-
+	attrs := attributesFromRecord(r)
 	if err != nil {
 		errorType := attribute.String("error", "other")
 		if errors.Is(err, context.DeadlineExceeded) {
 			errorType = attribute.String("error", "timeout")
-		}
-		if errors.Is(err, context.Canceled) {
+		} else if errors.Is(err, context.Canceled) {
 			errorType = attribute.String("error", "canceled")
 		}
 
@@ -100,4 +100,27 @@ func (h *metricHooks) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 	h.messageProduced.Add(context.Background(), 1,
 		metric.WithAttributes(attrs...),
 	)
+}
+
+// OnFetchRecordUnbuffered records the number of fetched messages.
+// https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookFetchRecordUnbuffered
+func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
+	h.messageFetched.Add(context.Background(), 1,
+		metric.WithAttributes(attributesFromRecord(r)...),
+	)
+}
+
+func attributesFromRecord(r *kgo.Record) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 5) // Preallocate 5 elements.
+	attrs = append(attrs,
+		semconv.MessagingDestinationName(r.Topic),
+		semconv.MessagingKafkaDestinationPartition(int(r.Partition)),
+	)
+	for _, v := range r.Headers {
+		if v.Key == "traceparent" { // Ignore traceparent header.
+			continue
+		}
+		attrs = append(attrs, attribute.String(v.Key, string(v.Value)))
+	}
+	return attrs
 }


### PR DESCRIPTION
Adds a new `consumer.messages.fetched` metric that records the number of fetched records from Kafka adding the record's headers as dimensions.