### PR TITLE
Kafka metrics: add MessagingSystem attribute

### DIFF
--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -113,6 +113,7 @@ func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
 func attributesFromRecord(r *kgo.Record) []attribute.KeyValue {
 	attrs := make([]attribute.KeyValue, 0, 5) // Preallocate 5 elements.
 	attrs = append(attrs,
+		semconv.MessagingSystem("kafka"),
 		semconv.MessagingDestinationName(r.Topic),
 		semconv.MessagingKafkaDestinationPartition(int(r.Partition)),
 	)

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -75,6 +75,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3, Attributes: attribute.NewSet(
 							attribute.String("error", "timeout"),
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
 							semconv.MessagingKafkaDestinationPartition(0),
 						),
@@ -99,6 +100,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3, Attributes: attribute.NewSet(
 							attribute.String("error", "canceled"),
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
 							semconv.MessagingKafkaDestinationPartition(0),
 						),
@@ -124,6 +126,7 @@ func TestProducerMetrics(t *testing.T) {
 						Value: 3,
 						Attributes: attribute.NewSet(
 							attribute.String("error", "other"),
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
 							semconv.MessagingKafkaDestinationPartition(0),
 						),
@@ -147,6 +150,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3,
 						Attributes: attribute.NewSet(
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
 							semconv.MessagingKafkaDestinationPartition(0),
 						),
@@ -169,6 +173,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3,
 						Attributes: attribute.NewSet(
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
 							semconv.MessagingKafkaDestinationPartition(0),
 							attribute.String("key", "value"),
@@ -239,6 +244,7 @@ func TestConsumerMetrics(t *testing.T) {
 				{
 					Value: int64(records),
 					Attributes: attribute.NewSet(
+						semconv.MessagingSystem("kafka"),
 						semconv.MessagingDestinationName(t.Name()),
 						semconv.MessagingKafkaDestinationPartition(0),
 						attribute.String("header", "included"),


### PR DESCRIPTION
To uniform with PubSubLite producer and consumer, add [`MessagingSystem`](https://pkg.go.dev/go.opentelemetry.io/otel@v1.16.0/semconv/v1.17.0#MessagingSystem) attribute to Kafka metrics.

The same `MessagingSystem` attribute is applied to PubSubLite [publisher][1] and [consumer][2] metrics.


[1]: https://github.com/elastic/apm-queue/blob/41bf286b91f83f497cebb2489faa0e87449e0e38/pubsublite/internal/telemetry/publisher.go#L146
[2]: https://github.com/elastic/apm-queue/blob/41bf286b91f83f497cebb2489faa0e87449e0e38/pubsublite/internal/telemetry/consumer.go#L66
