### PR TITLE
Add event delay metric on both producers

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -467,7 +467,10 @@ func TestConsumerContextPropagation(t *testing.T) {
 		Logger:  zap.NewNop(),
 	}
 	processed := make(chan struct{})
-	expectedMeta := map[string]string{"key": "value"}
+	expectedMeta := map[string]string{
+		"key":       "value",
+		"timestamp": time.Now().Format(time.RFC3339),
+	}
 	consumer := newConsumer(t, ConsumerConfig{
 		CommonConfig: commonCfg,
 		GroupID:      "ctx_prop",

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -137,6 +137,9 @@ func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
 			}
 
 			delay := time.Since(since).Seconds()
+			span.SetAttributes(
+				attribute.Float64(apmqueue.EventTimeKey, delay),
+			)
 			h.messageDelay.Record(r.Context, delay, metric.WithAttributes(
 				attrs...,
 			))

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -21,11 +21,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/twmb/franz-go/pkg/kgo"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+
+	apmqueue "github.com/elastic/apm-queue"
 )
 
 const (
@@ -36,12 +39,14 @@ const (
 	msgProducedKey = "producer.messages.produced"
 	msgErroredKey  = "producer.messages.errored"
 	msgFetchedKey  = "consumer.messages.fetched"
+	msgDelayKey    = "consumer.messages.delay"
 )
 
 type metricHooks struct {
 	messageProduced metric.Int64Counter
 	messageErrored  metric.Int64Counter
 	messageFetched  metric.Int64Counter
+	messageDelay    metric.Int64Histogram
 }
 
 func newKgoHooks(mp metric.MeterProvider) (*metricHooks, error) {
@@ -67,12 +72,22 @@ func newKgoHooks(mp metric.MeterProvider) (*metricHooks, error) {
 	if err != nil {
 		return nil, formatMetricError(msgFetchedKey, err)
 	}
+
+	messageDelayHistogram, err := m.Int64Histogram(msgDelayKey,
+		metric.WithDescription("The delay between producing messages and reading them"),
+		metric.WithUnit(unitCount),
+	)
+	if err != nil {
+		return nil, formatMetricError(msgDelayKey, err)
+	}
+
 	return &metricHooks{
 		// Producer
 		messageProduced: messageProducedCounter,
 		messageErrored:  messageErroredCounter,
 		// Consumer
 		messageFetched: messageFetchedCounter,
+		messageDelay:   messageDelayHistogram,
 	}, nil
 }
 
@@ -105,9 +120,22 @@ func (h *metricHooks) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 // OnFetchRecordUnbuffered records the number of fetched messages.
 // https://pkg.go.dev/github.com/twmb/franz-go/pkg/kgo#HookFetchRecordUnbuffered
 func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
+	attrs := attributesFromRecord(r)
+
 	h.messageFetched.Add(context.Background(), 1,
-		metric.WithAttributes(attributesFromRecord(r)...),
+		metric.WithAttributes(attrs...),
 	)
+
+	for _, v := range r.Headers {
+		if v.Key == apmqueue.EventTimeKey {
+			if since, err := time.Parse(time.RFC3339, string(v.Value)); err == nil {
+				delay := time.Since(since).Milliseconds()
+				h.messageDelay.Record(context.Background(), delay, metric.WithAttributes(
+					attrs...,
+				))
+			}
+		}
+	}
 }
 
 func attributesFromRecord(r *kgo.Record) []attribute.KeyValue {
@@ -117,7 +145,7 @@ func attributesFromRecord(r *kgo.Record) []attribute.KeyValue {
 		semconv.MessagingKafkaDestinationPartition(int(r.Partition)),
 	)
 	for _, v := range r.Headers {
-		if v.Key == "traceparent" { // Ignore traceparent header.
+		if v.Key == "traceparent" || v.Key == apmqueue.EventTimeKey { // Ignore traceparent and event time headers.
 			continue
 		}
 		attrs = append(attrs, attribute.String(v.Key, string(v.Value)))

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -244,6 +244,7 @@ func TestConsumerMetrics(t *testing.T) {
 					{
 						Value: int64(records),
 						Attributes: attribute.NewSet(
+							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName(t.Name()),
 							semconv.MessagingKafkaDestinationPartition(0),
 							attribute.String("header", "included"),

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -250,10 +250,10 @@ func TestConsumerMetrics(t *testing.T) {
 		{
 			Name:        "consumer.messages.delay",
 			Description: "The delay between producing messages and reading them",
-			Unit:        "1",
-			Data: metricdata.Histogram[int64]{
+			Unit:        "s",
+			Data: metricdata.Histogram[float64]{
 				Temporality: metricdata.CumulativeTemporality,
-				DataPoints: []metricdata.HistogramDataPoint[int64]{{
+				DataPoints: []metricdata.HistogramDataPoint[float64]{{
 					Attributes: attribute.NewSet(
 						semconv.MessagingDestinationName(t.Name()),
 						semconv.MessagingKafkaDestinationPartition(0),
@@ -274,10 +274,10 @@ func TestConsumerMetrics(t *testing.T) {
 		metric := metrics[k]
 
 		// Remove time-specific data for histograms
-		if dp, ok := metric.Data.(metricdata.Histogram[int64]); ok {
+		if dp, ok := metric.Data.(metricdata.Histogram[float64]); ok {
 			for k := range dp.DataPoints {
-				dp.DataPoints[k].Min = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Min
-				dp.DataPoints[k].Max = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Max
+				dp.DataPoints[k].Min = m.Data.(metricdata.Histogram[float64]).DataPoints[k].Min
+				dp.DataPoints[k].Max = m.Data.(metricdata.Histogram[float64]).DataPoints[k].Max
 				dp.DataPoints[k].Sum = 0
 				dp.DataPoints[k].BucketCounts = nil
 			}

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -212,6 +212,7 @@ func TestConsumerMetrics(t *testing.T) {
 			Headers: []kgo.RecordHeader{
 				{Key: "header", Value: []byte("included")},
 				{Key: "traceparent", Value: []byte("excluded")},
+				{Key: "timestamp", Value: []byte(time.Now().Format(time.RFC3339))},
 			},
 		})
 	}
@@ -226,27 +227,70 @@ func TestConsumerMetrics(t *testing.T) {
 	var rm metricdata.ResourceMetrics
 	assert.NoError(t, tc.reader.Collect(context.Background(), &rm))
 
-	metrics := filterMetrics(t, rm.ScopeMetrics)
-	assert.Len(t, metrics, 1)
-	metricdatatest.AssertEqual(t, metricdata.Metrics{
-		Name:        msgFetchedKey,
-		Description: "The number of messages that were fetched from a kafka topic",
-		Unit:        "1",
-		Data: metricdata.Sum[int64]{
-			Temporality: metricdata.CumulativeTemporality,
-			IsMonotonic: true,
-			DataPoints: []metricdata.DataPoint[int64]{
-				{
-					Value: int64(records),
+	wantMetrics := []metricdata.Metrics{
+		{
+			Name:        msgFetchedKey,
+			Description: "The number of messages that were fetched from a kafka topic",
+			Unit:        "1",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{
+						Value: int64(records),
+						Attributes: attribute.NewSet(
+							semconv.MessagingDestinationName(t.Name()),
+							semconv.MessagingKafkaDestinationPartition(0),
+							attribute.String("header", "included"),
+						),
+					},
+				},
+			},
+		},
+		{
+			Name:        "consumer.messages.delay",
+			Description: "The delay between producing messages and reading them",
+			Unit:        "1",
+			Data: metricdata.Histogram[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints: []metricdata.HistogramDataPoint[int64]{{
 					Attributes: attribute.NewSet(
 						semconv.MessagingDestinationName(t.Name()),
 						semconv.MessagingKafkaDestinationPartition(0),
 						attribute.String("header", "included"),
 					),
-				},
+
+					Bounds: []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000},
+					Count:  uint64(records),
+				}},
 			},
 		},
-	}, metrics[0], metricdatatest.IgnoreTimestamp())
+	}
+
+	metrics := filterMetrics(t, rm.ScopeMetrics)
+	assert.Len(t, metrics, len(wantMetrics))
+
+	for k, m := range wantMetrics {
+		metric := metrics[k]
+
+		// Remove time-specific data for histograms
+		if dp, ok := metric.Data.(metricdata.Histogram[int64]); ok {
+			for k := range dp.DataPoints {
+				dp.DataPoints[k].Min = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Min
+				dp.DataPoints[k].Max = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Max
+				dp.DataPoints[k].Sum = 0
+				dp.DataPoints[k].BucketCounts = nil
+			}
+			metric.Data = dp
+		}
+
+		metricdatatest.AssertEqual(t,
+			m,
+			metric,
+			metricdatatest.IgnoreTimestamp(),
+			metricdatatest.IgnoreExemplars(),
+		)
+	}
 }
 
 func filterMetrics(t testing.TB, sm []metricdata.ScopeMetrics) []metricdata.Metrics {

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -191,7 +191,7 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 		}
 	}
 	headers = append(headers, kgo.RecordHeader{
-		Key:   "timestamp",
+		Key:   apmqueue.EventTimeKey,
 		Value: []byte(now),
 	})
 

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -180,6 +181,7 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 	defer p.mu.RUnlock()
 
 	var headers []kgo.RecordHeader
+	now := time.Now().Format(time.RFC3339)
 	if m, ok := queuecontext.MetadataFromContext(ctx); ok {
 		headers = make([]kgo.RecordHeader, 0, len(m))
 		for k, v := range m {
@@ -188,6 +190,10 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 			})
 		}
 	}
+	headers = append(headers, kgo.RecordHeader{
+		Key:   "timestamp",
+		Value: []byte(now),
+	})
 
 	var wg sync.WaitGroup
 	wg.Add(len(rs))

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -123,6 +123,7 @@ func TestNewProducerBasic(t *testing.T) {
 				{Topic: topic, Value: []byte("2")},
 			}
 			spanCount := len(exp.GetSpans())
+			now := time.Now().Format(time.RFC3339)
 			if !sync {
 				// Cancel the context before calling Produce
 				ctxCancelled, cancelProduce := context.WithCancel(ctx)
@@ -154,6 +155,7 @@ func TestNewProducerBasic(t *testing.T) {
 				assert.Equal(t, []kgo.RecordHeader{
 					{Key: "a", Value: []byte("b")},
 					{Key: "c", Value: []byte("d")},
+					{Key: apmqueue.EventTimeKey, Value: []byte(now)},
 				}, record.Headers)
 			}
 

--- a/pubsublite/internal/telemetry/consumer.go
+++ b/pubsublite/internal/telemetry/consumer.go
@@ -135,6 +135,9 @@ func Consumer(
 					span.RecordError(err)
 				} else {
 					delay := time.Since(since).Seconds()
+					span.SetAttributes(
+						attribute.Float64(apmqueue.EventTimeKey, delay),
+					)
 					metrics.queuedDelay.Record(ctx, delay, metric.WithAttributes(
 						attrs...,
 					))

--- a/pubsublite/internal/telemetry/consumer.go
+++ b/pubsublite/internal/telemetry/consumer.go
@@ -44,7 +44,7 @@ const (
 // ConsumerMetrics holds the metrics that are recorded for consumers
 type ConsumerMetrics struct {
 	fetched     metric.Int64Counter
-	queuedDelay metric.Int64Histogram
+	queuedDelay metric.Float64Histogram
 }
 
 // NewConsumerMetrics instantiates the producer metrics.
@@ -58,9 +58,9 @@ func NewConsumerMetrics(mp metric.MeterProvider) (cm ConsumerMetrics, err error)
 		return cm, formatMetricError(msgFetchedKey, err)
 	}
 
-	cm.queuedDelay, err = m.Int64Histogram(msgDelayKey,
+	cm.queuedDelay, err = m.Float64Histogram(msgDelayKey,
 		metric.WithDescription("The delay between producing messages and reading them"),
-		metric.WithUnit("1"),
+		metric.WithUnit("s"),
 	)
 	if err != nil {
 		return cm, formatMetricError(msgDelayKey, err)
@@ -116,7 +116,7 @@ func Consumer(
 		if msg.Attributes != nil {
 			if msg.Attributes[apmqueue.EventTimeKey] != "" {
 				if since, err := time.Parse(time.RFC3339, msg.Attributes[apmqueue.EventTimeKey]); err == nil {
-					delay := time.Since(since).Milliseconds()
+					delay := time.Since(since).Seconds()
 					metrics.queuedDelay.Record(context.Background(), delay, metric.WithAttributes(
 						attrs...,
 					))

--- a/pubsublite/internal/telemetry/consumer.go
+++ b/pubsublite/internal/telemetry/consumer.go
@@ -22,6 +22,7 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 	"go.opentelemetry.io/otel"
@@ -31,27 +32,44 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.18.0"
 	"go.opentelemetry.io/otel/trace"
 
+	apmqueue "github.com/elastic/apm-queue"
 	"github.com/elastic/apm-queue/pubsublite/internal/pubsubabs"
+)
+
+const (
+	msgFetchedKey = "consumer.messages.fetched"
+	msgDelayKey   = "consumer.messages.delay"
 )
 
 // ConsumerMetrics holds the metrics that are recorded for consumers
 type ConsumerMetrics struct {
-	fetched metric.Int64Counter
+	fetched     metric.Int64Counter
+	queuedDelay metric.Int64Histogram
 }
 
 // NewConsumerMetrics instantiates the producer metrics.
 func NewConsumerMetrics(mp metric.MeterProvider) (cm ConsumerMetrics, err error) {
 	m := mp.Meter(instrumentName)
-	cm.fetched, err = m.Int64Counter("consumer.messages.fetched",
+	cm.fetched, err = m.Int64Counter(msgFetchedKey,
 		metric.WithDescription("The number of messages fetched"),
 		metric.WithUnit("1"),
 	)
 	if err != nil {
-		return cm, fmt.Errorf(
-			"telemetry: cannot create 'consumer.messages.fetched' metric: %w", err,
-		)
+		return cm, formatMetricError(msgFetchedKey, err)
+	}
+
+	cm.queuedDelay, err = m.Int64Histogram(msgDelayKey,
+		metric.WithDescription("The delay between producing messages and reading them"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return cm, formatMetricError(msgDelayKey, err)
 	}
 	return
+}
+
+func formatMetricError(name string, err error) error {
+	return fmt.Errorf("telemetry: cannot create %s metric: %w", name, err)
 }
 
 // Consumer decorates an existing consumer with tracing and metering.
@@ -84,7 +102,7 @@ func Consumer(
 				), commonAttrs...)
 			}
 			for key, v := range msg.Attributes {
-				if key == "traceparent" { // Ignore traceparent header.
+				if key == "traceparent" || key == apmqueue.EventTimeKey { // Ignore traceparent and event time headers.
 					continue
 				}
 				attrs = append(attrs, attribute.String(key, v))
@@ -94,7 +112,17 @@ func Consumer(
 		metrics.fetched.Add(context.Background(), 1, metric.WithAttributes(
 			attrs...,
 		))
+
 		if msg.Attributes != nil {
+			if msg.Attributes[apmqueue.EventTimeKey] != "" {
+				if since, err := time.Parse(time.RFC3339, msg.Attributes[apmqueue.EventTimeKey]); err == nil {
+					delay := time.Since(since).Milliseconds()
+					metrics.queuedDelay.Record(context.Background(), delay, metric.WithAttributes(
+						attrs...,
+					))
+				}
+			}
+
 			propagator := otel.GetTextMapPropagator()
 			ctx = propagator.Extract(ctx, propagation.MapCarrier(msg.Attributes))
 		}

--- a/pubsublite/internal/telemetry/consumer_test.go
+++ b/pubsublite/internal/telemetry/consumer_test.go
@@ -199,6 +199,7 @@ func TestConsumer(t *testing.T) {
 						semconv.MessagingOperationProcess,
 						semconv.MessagingMessageIDKey.String(""),
 						semconv.MessageUncompressedSize(0),
+						attribute.Float64("timestamp", 1.0),
 					},
 					InstrumentationLibrary: instrumentation.Library{
 						Name: "test",
@@ -382,6 +383,8 @@ func TestConsumerMultipleEvents(t *testing.T) {
 }
 
 func assertSpans(t testing.TB, traceID [16]byte, expected, actual tracetest.SpanStubs) {
+	t.Helper()
+
 	for i := range actual {
 		// Nullify data we don't use/can't set manually
 		actual[i].SpanContext = actual[i].SpanContext.
@@ -395,6 +398,12 @@ func assertSpans(t testing.TB, traceID [16]byte, expected, actual tracetest.Span
 		actual[i].Resource = nil
 		actual[i].StartTime = time.Time{}
 		actual[i].EndTime = time.Time{}
+
+		for j, v := range actual[i].Attributes {
+			if v.Key == apmqueue.EventTimeKey {
+				actual[i].Attributes[j].Value = attribute.Float64Value(1.0)
+			}
+		}
 	}
 	assert.Equal(t, expected, actual)
 }

--- a/pubsublite/internal/telemetry/consumer_test.go
+++ b/pubsublite/internal/telemetry/consumer_test.go
@@ -227,10 +227,10 @@ func TestConsumer(t *testing.T) {
 				{
 					Name:        "consumer.messages.delay",
 					Description: "The delay between producing messages and reading them",
-					Unit:        "1",
-					Data: metricdata.Histogram[int64]{
+					Unit:        "s",
+					Data: metricdata.Histogram[float64]{
 						Temporality: metricdata.CumulativeTemporality,
-						DataPoints: []metricdata.HistogramDataPoint[int64]{{
+						DataPoints: []metricdata.HistogramDataPoint[float64]{{
 							Attributes: attribute.NewSet(
 								attribute.String("project", "project_name"),
 								semconv.MessagingSystemKey.String("pubsublite"),
@@ -275,10 +275,10 @@ func TestConsumer(t *testing.T) {
 				metric := rm.ScopeMetrics[0].Metrics[k]
 
 				// Remove time-specific data for histograms
-				if dp, ok := metric.Data.(metricdata.Histogram[int64]); ok {
+				if dp, ok := metric.Data.(metricdata.Histogram[float64]); ok {
 					for k := range dp.DataPoints {
-						dp.DataPoints[k].Min = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Min
-						dp.DataPoints[k].Max = m.Data.(metricdata.Histogram[int64]).DataPoints[k].Max
+						dp.DataPoints[k].Min = m.Data.(metricdata.Histogram[float64]).DataPoints[k].Min
+						dp.DataPoints[k].Max = m.Data.(metricdata.Histogram[float64]).DataPoints[k].Max
 						dp.DataPoints[k].Sum = 0
 						dp.DataPoints[k].BucketCounts = nil
 					}

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -154,9 +154,9 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 	now := time.Now().Format(time.RFC3339)
 
 	for _, record := range rs {
-		msg := pubsub.Message{Data: record.Value}
-		if msg.Attributes == nil {
-			msg.Attributes = make(map[string]string)
+		msg := pubsub.Message{
+			Data:       record.Value,
+			Attributes: make(map[string]string),
 		}
 
 		if meta, ok := queuecontext.MetadataFromContext(ctx); ok {

--- a/queue.go
+++ b/queue.go
@@ -38,6 +38,10 @@ const (
 	// processed. It may or may not create duplicates, depending on how batches
 	// are processed by the underlying Processor.
 	AtLeastOnceDeliveryType
+
+	// EventTimeKey is a header added to every record which stores the time at
+	// which the event was produced, in RFC3339 format.
+	EventTimeKey = "timestamp"
 )
 
 // DeliveryType for the consumer. For more details See the supported DeliveryTypes.


### PR DESCRIPTION
This adds a new header on each producer record, `timestamp`, which stores the time when the record was produced.
It also emits a new metric, `consumer.messages.delay`, which is the delay in milliseconds it took to consume a record.