### PR TITLE
Use sha instead of ref in system-tests

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: hashicorp/setup-terraform@v2
         with:


### PR DESCRIPTION
## Details

In other discussions there was a concern, that there could be a short timeframe after the `is-pr-approved` action is done, where the`ref` could yield a new commit that is not actually verified.

This change should discard any ambiguity of which commit is checked out.
