### PR TITLE
Introduce ordering key for kafka and pubsublite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/pubsub v1.31.0
 	cloud.google.com/go/pubsublite v1.8.1
+	github.com/google/go-cmp v0.5.9
 	github.com/googleapis/gax-go/v2 v2.11.0
 	github.com/stretchr/testify v1.8.4
 	github.com/twmb/franz-go v1.13.5
@@ -39,7 +40,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/s2a-go v0.1.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.4 // indirect

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -464,7 +464,11 @@ func (pc partitionConsumer) consume(ctx context.Context, topic string, partition
 				meta[h.Key] = string(h.Value)
 			}
 			processCtx := queuecontext.WithMetadata(msg.Context, meta)
-			record := apmqueue.Record{Topic: apmqueue.Topic(topic), Value: msg.Value}
+			record := apmqueue.Record{
+				Topic:       apmqueue.Topic(topic),
+				OrderingKey: msg.Key,
+				Value:       msg.Value,
+			}
 			// If a record can't be processed, no retries are attempted and it
 			// may be lost. https://github.com/elastic/apm-queue/issues/118.
 			if err := pc.processor.Process(processCtx, record); err != nil {

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -204,6 +204,7 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 		kgoRecord := &kgo.Record{
 			Headers: headers,
 			Topic:   string(record.Topic),
+			Key:     record.OrderingKey,
 			Value:   record.Value,
 		}
 		p.client.Produce(ctx, kgoRecord, func(r *kgo.Record, err error) {

--- a/pubsublite/consumer.go
+++ b/pubsublite/consumer.go
@@ -262,7 +262,11 @@ func (c *consumer) processMessage(ctx context.Context, msg *pubsub.Message) {
 			}
 		}()
 	}
-	record := apmqueue.Record{Topic: c.topic, Value: msg.Data}
+	record := apmqueue.Record{
+		Topic:       c.topic,
+		OrderingKey: []byte(msg.OrderingKey),
+		Value:       msg.Data,
+	}
 	if err = c.processor.Process(ctx, record); err != nil {
 		partition, offset := partitionOffset(msg.ID)
 		c.logger.Error("unable to process event",

--- a/pubsublite/producer.go
+++ b/pubsublite/producer.go
@@ -155,8 +155,9 @@ func (p *Producer) Produce(ctx context.Context, rs ...apmqueue.Record) error {
 
 	for _, record := range rs {
 		msg := pubsub.Message{
-			Data:       record.Value,
-			Attributes: make(map[string]string),
+			OrderingKey: string(record.OrderingKey),
+			Data:        record.Value,
+			Attributes:  make(map[string]string),
 		}
 
 		if meta, ok := queuecontext.MetadataFromContext(ctx); ok {

--- a/queue.go
+++ b/queue.go
@@ -81,6 +81,9 @@ type Producer interface {
 type Record struct {
 	// Topics holds the topic where the record will be produced.
 	Topic Topic
+	// OrderingKey is an optional field that is hashed to map to a partition.
+	// Records with same ordering key are routed to the same partition.
+	OrderingKey []byte
 	// Value holds the record's content. It must not be mutated after Produce.
 	Value []byte
 }

--- a/systemtest/infra_kafka.go
+++ b/systemtest/infra_kafka.go
@@ -144,8 +144,8 @@ func DestroyKafka(ctx context.Context) error {
 // CreateKafkaTopics interacts with the Kafka broker to create topics,
 // deleting them when the test completes.
 //
-// Topics are created with 1 partition and 1 hour of retention.
-func CreateKafkaTopics(ctx context.Context, t testing.TB, topics ...apmqueue.Topic) {
+// Topics are created with given partitions and 1 hour of retention.
+func CreateKafkaTopics(ctx context.Context, t testing.TB, partitions int, topics ...apmqueue.Topic) {
 	manager, err := NewKafkaManager(t)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -153,7 +153,7 @@ func CreateKafkaTopics(ctx context.Context, t testing.TB, topics ...apmqueue.Top
 	})
 
 	topicCreator, err := manager.NewTopicCreator(kafka.TopicCreatorConfig{
-		PartitionCount: 1,
+		PartitionCount: partitions,
 		TopicConfigs: map[string]string{
 			"retention.ms": strconv.FormatInt(time.Hour.Milliseconds(), 10),
 		},

--- a/systemtest/produce_consume_basic_test.go
+++ b/systemtest/produce_consume_basic_test.go
@@ -93,7 +93,7 @@ func TestProduceConsumeOrderingKeys(t *testing.T) {
 		runAsyncAndSync(t, func(t *testing.T, isSync bool) {
 			var records atomic.Int64
 			processor := sequenceConsumerAssertionProcessor(t, &sequenceConsumerAssertions{
-				consumerAssertions: consumerAssertions{records: &records},
+				records: &records,
 			}, func(r apmqueue.Record) int {
 				assert.Equal(t, orderingKey, r.OrderingKey)
 				seq, err := strconv.Atoi(string(r.Value))
@@ -197,7 +197,7 @@ func assertProcessor(t testing.TB, assertions consumerAssertions) apmqueue.Proce
 // assuming that all records are sent to same partitions. If records are
 // not sent to same partition then it will result in failures.
 type sequenceConsumerAssertions struct {
-	consumerAssertions
+	records  *atomic.Int64
 	lastSeen atomic.Int32
 }
 

--- a/systemtest/produce_consume_basic_test.go
+++ b/systemtest/produce_consume_basic_test.go
@@ -83,9 +83,9 @@ func TestProduceConsumeOrderingKeys(t *testing.T) {
 
 	// Use a high event count to circumvent the UniformBytesPartitioner
 	// used by franz-go by default which aims to produce large batches of
-	// data to same partition.
-	events := 2000
-	partitions := 4
+	// data to same partition if no ordering keys is specified.
+	events := 1500
+	partitions := 2
 	timeout := 60 * time.Second
 	orderingKey := []byte("fixed")
 


### PR DESCRIPTION
The ordering key allows Kafka and Pubsublite to ensure that a record with the same ordering key is routed to the same partition.

Franz-go library, by default, uses a [UniformBytesPartitioner](https://github.com/twmb/franz-go/blob/6147cee6468484e5dfab6febf4b76962dffaee38/pkg/kgo/config.go#L499) with ordering keys enabled and default murmur2 hasher. The `UniformBytesPartitioner` with ordering keys enabled uses the configured hash function to map a record with `Key` to a specific partition ([ref](https://github.com/twmb/franz-go/blob/6147cee6468484e5dfab6febf4b76962dffaee38/pkg/kgo/partitioner.go#L323-L325)). This means that we can keep using the default partitioner and satisfy the requirement for ordering keys.