### PR TITLE
pubsublite: monitoring: Filter by location on client side

### DIFF
--- a/pubsublite/manager.go
+++ b/pubsublite/manager.go
@@ -275,9 +275,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 	}
 
 	filter := fmt.Sprintf("metric.type = \"pubsublite.googleapis.com/subscription/backlog_message_count\""+
-		" AND resource.labels.location = \"%s\""+
 		" AND (%s)",
-		m.cfg.Region,
 		strings.Join(subscriptionIDFilters, " OR "))
 
 	gatherMetrics := func(ctx context.Context, o metric.Observer) error {
@@ -298,6 +296,11 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 			if err != nil {
 				m.cfg.Logger.Error("error reading from monitoring time series iterator", zap.Error(err))
 				return fmt.Errorf("error reading from monitoring time series iterator: %w", err)
+			}
+
+			location := resp.Resource.Labels["location"]
+			if location != m.cfg.Region {
+				continue
 			}
 
 			subscriptionID := resp.Resource.Labels["subscription_id"]

--- a/pubsublite/manager_test.go
+++ b/pubsublite/manager_test.go
@@ -675,6 +675,5 @@ func TestManagerMetrics(t *testing.T) {
 	}, metrics[0].Data, metricdatatest.IgnoreTimestamp())
 
 	assert.Equal(t, testAdminService.TimeSeriesFilter, "metric.type = \"pubsublite.googleapis.com/subscription/backlog_message_count\""+
-		" AND resource.labels.location = \"region-1\""+
 		" AND (resource.labels.subscription_id = \"topic1+consumer1\" OR resource.labels.subscription_id = \"topic2+consumer1\")")
 }

--- a/pubsublite/manager_test.go
+++ b/pubsublite/manager_test.go
@@ -582,6 +582,7 @@ func (s *adminAndMetricServiceServer) ListTimeSeries(ctx context.Context, req *m
 					Labels: map[string]string{
 						"subscription_id": "topic1+consumer1",
 						"partition":       "1",
+						"location":        "region-1",
 					},
 				},
 				Metadata:   nil,
@@ -598,12 +599,30 @@ func (s *adminAndMetricServiceServer) ListTimeSeries(ctx context.Context, req *m
 					Labels: map[string]string{
 						"subscription_id": "topic2+consumer1",
 						"partition":       "2",
+						"location":        "region-1",
 					},
 				},
 				Metadata:   nil,
 				MetricKind: metricpb.MetricDescriptor_GAUGE,
 				ValueType:  metricpb.MetricDescriptor_INT64,
 				Points:     []*monitoringpb.Point{{Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 2}}}},
+				Unit:       "",
+			},
+			{
+				Metric: &metricpb.Metric{
+					Type: "pubsublite.googleapis.com/subscription/backlog_message_count",
+				},
+				Resource: &monitoredres.MonitoredResource{
+					Labels: map[string]string{
+						"subscription_id": "topic2+consumer1",
+						"partition":       "3",
+						"location":        "region-2",
+					},
+				},
+				Metadata:   nil,
+				MetricKind: metricpb.MetricDescriptor_GAUGE,
+				ValueType:  metricpb.MetricDescriptor_INT64,
+				Points:     []*monitoringpb.Point{{Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{Int64Value: 3}}}},
 				Unit:       "",
 			},
 		},


### PR DESCRIPTION
Fix "AND and OR cannot be mixed for 'resource.labels' restrictions"