### PR TITLE
kafka: Use `Source*` consumer metric attributes

### DIFF
--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -244,8 +244,8 @@ func TestConsumerMetrics(t *testing.T) {
 						Value: int64(records),
 						Attributes: attribute.NewSet(
 							semconv.MessagingSystem("kafka"),
-							semconv.MessagingDestinationName(t.Name()),
-							semconv.MessagingKafkaDestinationPartition(0),
+							semconv.MessagingSourceName(t.Name()),
+							semconv.MessagingKafkaSourcePartition(0),
 							attribute.String("header", "included"),
 						),
 					},
@@ -261,8 +261,8 @@ func TestConsumerMetrics(t *testing.T) {
 				DataPoints: []metricdata.HistogramDataPoint[float64]{{
 					Attributes: attribute.NewSet(
 						semconv.MessagingSystem("kafka"),
-						semconv.MessagingDestinationName(t.Name()),
-						semconv.MessagingKafkaDestinationPartition(0),
+						semconv.MessagingSourceName(t.Name()),
+						semconv.MessagingKafkaSourcePartition(0),
 						attribute.String("header", "included"),
 					),
 


### PR DESCRIPTION
Updates the consumer to use the Source rather than Destination attrs.