### PR TITLE
pubsublite: add resource namespacing

### DIFF
--- a/pubsublite/common.go
+++ b/pubsublite/common.go
@@ -50,6 +50,13 @@ type CommonConfig struct {
 	// This is added as a prefix for reservation, topic, and
 	// subscription names, and acts as a filter on resources
 	// monitored or described by the manager.
+	//
+	// Namespace is always removed from resource names before
+	// they are returned to callers. The only way Namespace
+	// will surface is in telemetry (e.g. metrics), as an
+	// independent dimension. This enables users to filter
+	// metrics by namespace, while maintaining stable names
+	// for resources (e.g. topics).
 	Namespace string
 
 	// ClientOptions holds arbitrary Google API client options.

--- a/pubsublite/consumer_test.go
+++ b/pubsublite/consumer_test.go
@@ -19,11 +19,20 @@ package pubsublite
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net"
 	"strings"
+	"sync"
 	"testing"
 
+	"cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	apmqueue "github.com/elastic/apm-queue"
 )
@@ -32,12 +41,12 @@ func TestNewConsumer(t *testing.T) {
 	t.Run("empty config", func(t *testing.T) {
 		_, err := NewConsumer(context.Background(), ConsumerConfig{})
 		assert.EqualError(t, err, "pubsublite: invalid consumer config: "+strings.Join([]string{
-			"pubsublite: project must be set",
-			"pubsublite: region must be set",
-			"pubsublite: logger must be set",
-			"pubsublite: at least one topic must be set",
-			"pubsublite: consumer name must be set",
-			"pubsublite: processor must be set",
+			"logger must be set",
+			"region must be set",
+			"project must be set",
+			"at least one topic must be set",
+			"consumer name must be set",
+			"processor must be set",
 		}, "\n"))
 	})
 
@@ -60,6 +69,283 @@ func TestNewConsumer(t *testing.T) {
 		config.Delivery = 100
 		_, err := NewConsumer(context.Background(), config)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "pubsublite: invalid consumer config: pubsublite: delivery is not valid")
+		assert.EqualError(t, err, "pubsublite: invalid consumer config: delivery is not valid")
 	})
+}
+
+func TestConsumerConsume(t *testing.T) {
+	type subscriptionPartition struct {
+		Subscription string
+		Partition    int64
+	}
+
+	ch := make(chan apmqueue.Record)
+	server, config := newConsumerService(t)
+	topic1SubscriptionPath := "projects/project/locations/region-1/subscriptions/name_space-topic1+consumer_name"
+	topic2SubscriptionPath := "projects/project/locations/region-1/subscriptions/name_space-topic2+consumer_name"
+
+	server.startSession = func(session *subscriberSession, _ *pubsublitepb.SeekRequest) {
+		switch session.subscription {
+		case topic1SubscriptionPath:
+		case topic2SubscriptionPath:
+		default:
+			panic("unexpected subscription: " + session.subscription)
+		}
+		switch session.partition {
+		case 1, 2:
+		default:
+			panic(fmt.Errorf("unexpected partition: %d", session.partition))
+		}
+		orderingKey, _ := json.Marshal(subscriptionPartition{
+			Subscription: session.subscription,
+			Partition:    session.partition,
+		})
+		session.messages <- []*pubsublitepb.SequencedMessage{{
+			Cursor: &pubsublitepb.Cursor{Offset: 0},
+			Message: &pubsublitepb.PubSubMessage{
+				Key:  orderingKey,
+				Data: []byte("message1"),
+			},
+		}, {
+			Cursor: &pubsublitepb.Cursor{Offset: 1},
+			Message: &pubsublitepb.PubSubMessage{
+				Key:  orderingKey,
+				Data: []byte("message2"),
+			},
+		}}
+	}
+	server.process = func(ctx context.Context, records ...apmqueue.Record) error {
+		if n := len(records); n != 1 {
+			panic(fmt.Errorf("expected 1 record, got %d", n))
+		}
+		ch <- records[0]
+		return nil
+	}
+
+	consumer, err := NewConsumer(context.Background(), config)
+	require.NoError(t, err)
+	defer consumer.Close()
+	go consumer.Run(context.Background())
+
+	// We should receive 2 records for each subscription-partition.
+	records := make(map[subscriptionPartition][]apmqueue.Record)
+	for i := 0; i < 8; i++ {
+		record := <-ch
+		var sp subscriptionPartition
+		err := json.Unmarshal(record.OrderingKey, &sp)
+		require.NoError(t, err)
+		record.OrderingKey = nil // simplify comparison below
+		records[sp] = append(records[sp], record)
+	}
+
+	assert.Equal(t, map[subscriptionPartition][]apmqueue.Record{
+		subscriptionPartition{
+			Subscription: topic1SubscriptionPath,
+			Partition:    1,
+		}: []apmqueue.Record{
+			{Topic: "topic1", Value: []byte("message1")},
+			{Topic: "topic1", Value: []byte("message2")},
+		},
+
+		subscriptionPartition{
+			Subscription: topic1SubscriptionPath,
+			Partition:    2,
+		}: []apmqueue.Record{
+			{Topic: "topic1", Value: []byte("message1")},
+			{Topic: "topic1", Value: []byte("message2")},
+		},
+
+		subscriptionPartition{
+			Subscription: topic2SubscriptionPath,
+			Partition:    1,
+		}: []apmqueue.Record{
+			{Topic: "topic2", Value: []byte("message1")},
+			{Topic: "topic2", Value: []byte("message2")},
+		},
+
+		subscriptionPartition{
+			Subscription: topic2SubscriptionPath,
+			Partition:    2,
+		}: []apmqueue.Record{
+			{Topic: "topic2", Value: []byte("message1")},
+			{Topic: "topic2", Value: []byte("message2")},
+		},
+	}, records)
+}
+
+func newConsumerService(t testing.TB) (*subscriberServiceServer, ConsumerConfig) {
+	s := grpc.NewServer()
+	t.Cleanup(s.Stop)
+	server := &subscriberServiceServer{
+		startSession: func(*subscriberSession, *pubsublitepb.SeekRequest) {},
+		process: func(ctx context.Context, records ...apmqueue.Record) error {
+			return nil
+		},
+	}
+	pubsublitepb.RegisterCursorServiceServer(s, server)
+	pubsublitepb.RegisterPartitionAssignmentServiceServer(s, server)
+	pubsublitepb.RegisterSubscriberServiceServer(s, server)
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { lis.Close() })
+	go s.Serve(lis)
+
+	return server, ConsumerConfig{
+		CommonConfig: CommonConfig{
+			Project:   "project",
+			Region:    "region-1",
+			Namespace: "name_space",
+			Logger:    zap.NewNop(),
+			ClientOptions: []option.ClientOption{
+				option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+				option.WithEndpoint(lis.Addr().String()),
+				option.WithoutAuthentication(),
+			},
+		},
+		ConsumerName: "consumer_name",
+		Topics:       []apmqueue.Topic{"topic1", "topic2"},
+		Delivery:     apmqueue.AtMostOnceDeliveryType,
+		Processor: apmqueue.ProcessorFunc(func(ctx context.Context, records ...apmqueue.Record) error {
+			if server.process != nil {
+				return server.process(ctx, records...)
+			}
+			return nil
+		}),
+	}
+}
+
+type subscriberServiceServer struct {
+	pubsublitepb.UnimplementedCursorServiceServer
+	pubsublitepb.UnimplementedPartitionAssignmentServiceServer
+	pubsublitepb.UnimplementedSubscriberServiceServer
+
+	startSession func(*subscriberSession, *pubsublitepb.SeekRequest)
+	process      apmqueue.ProcessorFunc
+}
+
+type subscriberSession struct {
+	subscription string
+	partition    int64
+	messages     chan []*pubsublitepb.SequencedMessage
+
+	mu              sync.RWMutex
+	cursor          int64
+	allowedBytes    int64
+	allowedMessages int64
+}
+
+func (s *subscriberServiceServer) Subscribe(ss pubsublitepb.SubscriberService_SubscribeServer) error {
+	session := subscriberSession{
+		messages: make(chan []*pubsublitepb.SequencedMessage, 1),
+	}
+	requests := make(chan *pubsublitepb.SubscribeRequest)
+
+	ctx, cancel := context.WithCancelCause(ss.Context())
+	defer cancel(nil)
+	go func() {
+		for {
+			req, err := ss.Recv()
+			if err != nil {
+				cancel(err)
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case requests <- req:
+			}
+		}
+	}()
+
+	for {
+		var req *pubsublitepb.SubscribeRequest
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case messages := <-session.messages:
+			if err := ss.Send(&pubsublitepb.SubscribeResponse{
+				Response: &pubsublitepb.SubscribeResponse_Messages{
+					Messages: &pubsublitepb.MessageResponse{
+						Messages: messages,
+					},
+				},
+			}); err != nil {
+				return err
+			}
+			continue
+		case req = <-requests:
+		}
+		if req := req.GetInitial(); req != nil {
+			session.subscription = req.Subscription
+			session.partition = req.Partition
+			s.startSession(&session, req.InitialLocation)
+			if err := ss.Send(&pubsublitepb.SubscribeResponse{
+				Response: &pubsublitepb.SubscribeResponse_Initial{
+					Initial: &pubsublitepb.InitialSubscribeResponse{
+						Cursor: &pubsublitepb.Cursor{
+							Offset: session.cursor,
+						},
+					},
+				},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		if req := req.GetFlowControl(); req != nil {
+			session.mu.Lock()
+			session.allowedBytes = req.AllowedBytes
+			session.allowedMessages = req.AllowedMessages
+			session.mu.Unlock()
+			continue
+		}
+	}
+}
+
+func (*subscriberServiceServer) StreamingCommitCursor(cs pubsublitepb.CursorService_StreamingCommitCursorServer) error {
+	for {
+		req, err := cs.Recv()
+		if err != nil {
+			return err
+		}
+		if req := req.GetInitial(); req != nil {
+			if err := cs.Send(&pubsublitepb.StreamingCommitCursorResponse{
+				Request: &pubsublitepb.StreamingCommitCursorResponse_Initial{},
+			}); err != nil {
+				return err
+			}
+		}
+		if req := req.GetCommit(); req != nil {
+			if err := cs.Send(&pubsublitepb.StreamingCommitCursorResponse{
+				Request: &pubsublitepb.StreamingCommitCursorResponse_Commit{
+					Commit: &pubsublitepb.SequencedCommitCursorResponse{
+						AcknowledgedCommits: 1,
+					},
+				},
+			}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *subscriberServiceServer) AssignPartitions(aps pubsublitepb.PartitionAssignmentService_AssignPartitionsServer) error {
+	for {
+		req, err := aps.Recv()
+		if err != nil {
+			return err
+		}
+		if req := req.GetInitial(); req != nil {
+			if err := aps.Send(&pubsublitepb.PartitionAssignment{
+				Partitions: []int64{1, 2},
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		if req := req.GetAck(); req != nil {
+			continue
+		}
+	}
 }

--- a/pubsublite/manager.go
+++ b/pubsublite/manager.go
@@ -44,10 +44,12 @@ type ManagerConfig struct {
 	CommonConfig
 }
 
-// Validate checks that cfg is valid, and returns an error otherwise.
-func (cfg ManagerConfig) Validate() error {
+// finalize ensures the configuration is valid, setting default values from
+// environment variables as described in doc comments, returning an error if
+// any configuration is invalid.
+func (cfg *ManagerConfig) finalize() error {
 	var errs []error
-	if err := cfg.CommonConfig.Validate(); err != nil {
+	if err := cfg.CommonConfig.finalize(); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
@@ -62,10 +64,7 @@ type Manager struct {
 
 // NewManager returns a new Manager with the given config.
 func NewManager(cfg ManagerConfig) (*Manager, error) {
-	if err := cfg.CommonConfig.setFromEnv(); err != nil {
-		return nil, fmt.Errorf("pubsublite: failed to set config from environment: %w", err)
-	}
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("pubsublite: invalid manager config: %w", err)
 	}
 	client, err := pubsublite.NewAdminClient(
@@ -89,9 +88,14 @@ func (m *Manager) Close() error {
 }
 
 // ListReservations lists reservations in the configured project and region.
+//
+// If the CommonConfig.Namespace is non-empty, then only reservations matching
+// that namespace are returned; the returned reservation name does not include
+// the namespace.
 func (m *Manager) ListReservations(ctx context.Context) ([]string, error) {
 	parent := fmt.Sprintf("projects/%s/locations/%s", m.cfg.Project, m.cfg.Region)
 	iter := m.client.Reservations(ctx, parent)
+	namespacePrefix := m.cfg.namespacePrefix()
 	var names []string
 	for {
 		reservation, err := iter.Next()
@@ -101,13 +105,22 @@ func (m *Manager) ListReservations(ctx context.Context) ([]string, error) {
 			}
 			return nil, fmt.Errorf("pubsublite: failed listing reservations: %w", err)
 		}
-		names = append(names, path.Base(reservation.Name))
+		reservationName := path.Base(reservation.Name)
+		if !strings.HasPrefix(reservationName, namespacePrefix) {
+			continue
+		}
+		names = append(names, reservationName[len(namespacePrefix):])
 	}
 }
 
 // ListReservationTopics lists topics in the given reservation.
 func (m *Manager) ListReservationTopics(ctx context.Context, reservation string) ([]string, error) {
-	parent := fmt.Sprintf("projects/%s/locations/%s/reservations/%s", m.cfg.Project, m.cfg.Region, reservation)
+	namespacePrefix := m.cfg.namespacePrefix()
+	parent := fmt.Sprintf(
+		"projects/%s/locations/%s/reservations/%s%s",
+		m.cfg.Project, m.cfg.Region,
+		namespacePrefix, reservation,
+	)
 	iter := m.client.ReservationTopics(ctx, parent)
 	var names []string
 	for {
@@ -118,13 +131,22 @@ func (m *Manager) ListReservationTopics(ctx context.Context, reservation string)
 			}
 			return nil, fmt.Errorf("pubsublite: failed listing topics for reservation %q: %w", reservation, err)
 		}
-		names = append(names, path.Base(topicPath))
+		topicName := path.Base(topicPath)
+		if !strings.HasPrefix(topicName, namespacePrefix) {
+			continue
+		}
+		names = append(names, topicName[len(namespacePrefix):])
 	}
 }
 
 // ListTopicSubscriptions lists subscriptions for the given topic.
 func (m *Manager) ListTopicSubscriptions(ctx context.Context, topic string) ([]string, error) {
-	parent := fmt.Sprintf("projects/%s/locations/%s/topics/%s", m.cfg.Project, m.cfg.Region, topic)
+	namespacePrefix := m.cfg.namespacePrefix()
+	parent := fmt.Sprintf(
+		"projects/%s/locations/%s/topics/%s%s",
+		m.cfg.Project, m.cfg.Region,
+		namespacePrefix, topic,
+	)
 	iter := m.client.TopicSubscriptions(ctx, parent)
 	var names []string
 	for {
@@ -135,7 +157,11 @@ func (m *Manager) ListTopicSubscriptions(ctx context.Context, topic string) ([]s
 			}
 			return nil, fmt.Errorf("pubsublite: failed listing subscriptions for topic %q: %w", topic, err)
 		}
-		names = append(names, path.Base(subscriptionPath))
+		subscriptionName := path.Base(subscriptionPath)
+		if !strings.HasPrefix(subscriptionName, namespacePrefix) {
+			continue
+		}
+		names = append(names, subscriptionName[len(namespacePrefix):])
 	}
 }
 
@@ -146,8 +172,8 @@ func (m *Manager) CreateReservation(ctx context.Context, name string, throughput
 	logger := m.cfg.Logger.With(zap.String("reservation", name))
 	_, err := m.client.CreateReservation(ctx, pubsublite.ReservationConfig{
 		Name: fmt.Sprintf(
-			"projects/%s/locations/%s/reservations/%s",
-			m.cfg.Project, m.cfg.Region, name,
+			"projects/%s/locations/%s/reservations/%s%s",
+			m.cfg.Project, m.cfg.Region, m.cfg.namespacePrefix(), name,
 		),
 		ThroughputCapacity: throughputCapacity,
 	})
@@ -173,18 +199,19 @@ func (m *Manager) CreateSubscription(
 		zap.String("subscription", name),
 		zap.String("topic", topic),
 	)
+	namespacePrefix := m.cfg.namespacePrefix()
 	deliveryRequirement := pubsublite.DeliverAfterStored
 	if deliverImmediately {
 		deliveryRequirement = pubsublite.DeliverImmediately
 	}
 	_, err := m.client.CreateSubscription(ctx, pubsublite.SubscriptionConfig{
 		Name: fmt.Sprintf(
-			"projects/%s/locations/%s/subscriptions/%s",
-			m.cfg.Project, m.cfg.Region, name,
+			"projects/%s/locations/%s/subscriptions/%s%s",
+			m.cfg.Project, m.cfg.Region, namespacePrefix, name,
 		),
 		Topic: fmt.Sprintf(
-			"projects/%s/locations/%s/topics/%s",
-			m.cfg.Project, m.cfg.Region, topic,
+			"projects/%s/locations/%s/topics/%s%s",
+			m.cfg.Project, m.cfg.Region, namespacePrefix, topic,
 		),
 		DeliveryRequirement: deliveryRequirement,
 	}, pubsublite.AtTargetLocation(pubsublite.Beginning))
@@ -210,7 +237,8 @@ func (m *Manager) CreateSubscription(
 func (m *Manager) DeleteReservation(ctx context.Context, reservation string) error {
 	logger := m.cfg.Logger.With(zap.String("reservation", reservation))
 	if err := m.client.DeleteReservation(ctx, fmt.Sprintf(
-		"projects/%s/locations/%s/reservations/%s", m.cfg.Project, m.cfg.Region, reservation,
+		"projects/%s/locations/%s/reservations/%s%s",
+		m.cfg.Project, m.cfg.Region, m.cfg.namespacePrefix(), reservation,
 	)); err != nil {
 		if err, ok := apierror.FromError(err); ok && err.Reason() == "RESOURCE_NOT_EXIST" {
 			logger.Debug("pubsublite reservation does not exist")
@@ -228,7 +256,8 @@ func (m *Manager) DeleteReservation(ctx context.Context, reservation string) err
 func (m *Manager) DeleteTopic(ctx context.Context, topic string) error {
 	logger := m.cfg.Logger.With(zap.String("topic", topic))
 	if err := m.client.DeleteTopic(ctx, fmt.Sprintf(
-		"projects/%s/locations/%s/topics/%s", m.cfg.Project, m.cfg.Region, topic,
+		"projects/%s/locations/%s/topics/%s%s",
+		m.cfg.Project, m.cfg.Region, m.cfg.namespacePrefix(), topic,
 	)); err != nil {
 		if err, ok := apierror.FromError(err); ok && err.Reason() == "RESOURCE_NOT_EXIST" {
 			logger.Debug("pubsublite topic does not exist")
@@ -246,7 +275,8 @@ func (m *Manager) DeleteTopic(ctx context.Context, topic string) error {
 func (m *Manager) DeleteSubscription(ctx context.Context, subscription string) error {
 	logger := m.cfg.Logger.With(zap.String("subscription", subscription))
 	if err := m.client.DeleteSubscription(ctx, fmt.Sprintf(
-		"projects/%s/locations/%s/subscriptions/%s", m.cfg.Project, m.cfg.Region, subscription,
+		"projects/%s/locations/%s/subscriptions/%s%s",
+		m.cfg.Project, m.cfg.Region, m.cfg.namespacePrefix(), subscription,
 	)); err != nil {
 		if err, ok := apierror.FromError(err); ok && err.Reason() == "RESOURCE_NOT_EXIST" {
 			logger.Debug("pubsublite subscription does not exist")
@@ -268,15 +298,26 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 		return nil, fmt.Errorf("pubsublite: failed to create consumer_group_lag metric: %w", err)
 	}
 
+	namespacePrefix := m.cfg.namespacePrefix()
 	subscriptionIDFilters := make([]string, len(topicConsumers))
 	for i, tc := range topicConsumers {
-		subscriptionIDFilters[i] = fmt.Sprintf("resource.labels.subscription_id = \"%s\"",
-			JoinTopicConsumer(tc.Topic, tc.Consumer))
+		subscriptionIDFilters[i] = fmt.Sprintf(
+			"resource.labels.subscription_id = \"%s%s\"",
+			namespacePrefix,
+			JoinTopicConsumer(tc.Topic, tc.Consumer),
+		)
 	}
-
 	filter := fmt.Sprintf("metric.type = \"pubsublite.googleapis.com/subscription/backlog_message_count\""+
 		" AND (%s)",
 		strings.Join(subscriptionIDFilters, " OR "))
+
+	var commonAttributes []attribute.KeyValue
+	if m.cfg.Namespace != "" {
+		commonAttributes = append(
+			commonAttributes,
+			attribute.String("namespace", m.cfg.Namespace),
+		)
+	}
 
 	gatherMetrics := func(ctx context.Context, o metric.Observer) error {
 		it := m.monitoringClient.ListTimeSeries(ctx, &monitoringpb.ListTimeSeriesRequest{
@@ -303,12 +344,12 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 				continue
 			}
 
-			subscriptionID := resp.Resource.Labels["subscription_id"]
+			subscriptionID := resp.Resource.Labels["subscription_id"][len(namespacePrefix):]
 			partition, err := strconv.Atoi(resp.Resource.Labels["partition"])
 			if err != nil {
 				m.cfg.Logger.Warn("error parsing partition id",
 					zap.Error(err),
-					zap.String("subscription_id", subscriptionID),
+					zap.String("subscription", subscriptionID),
 					zap.String("partition_string", resp.Resource.Labels["partition"]),
 				)
 				partition = -1
@@ -318,7 +359,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 			if len(points) == 0 {
 				m.cfg.Logger.Warn("empty points in monitoring time series",
 					zap.Error(err),
-					zap.String("subscription_id", subscriptionID),
+					zap.String("subscription", subscriptionID),
 					zap.Int("partition", partition),
 				)
 				continue
@@ -338,6 +379,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 
 			o.ObserveInt64(
 				consumerGroupLagMetric, lag,
+				metric.WithAttributes(commonAttributes...),
 				metric.WithAttributes(
 					attribute.String("topic", string(topic)),
 					attribute.String("group", consumer),

--- a/pubsublite/manager.go
+++ b/pubsublite/manager.go
@@ -88,10 +88,6 @@ func (m *Manager) Close() error {
 }
 
 // ListReservations lists reservations in the configured project and region.
-//
-// If the CommonConfig.Namespace is non-empty, then only reservations matching
-// that namespace are returned; the returned reservation name does not include
-// the namespace.
 func (m *Manager) ListReservations(ctx context.Context) ([]string, error) {
 	parent := fmt.Sprintf("projects/%s/locations/%s", m.cfg.Project, m.cfg.Region)
 	iter := m.client.Reservations(ctx, parent)

--- a/pubsublite/topiccreator_test.go
+++ b/pubsublite/topiccreator_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	pubsublitepb "cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
+	"cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -46,12 +46,12 @@ func TestManagerNewTopicCreator(t *testing.T) {
 	_, err = manager.NewTopicCreator(TopicCreatorConfig{})
 	require.Error(t, err)
 	assert.EqualError(t, err, "pubsublite: invalid topic creator config: "+strings.Join([]string{
-		"pubsublite: reservation must be set",
-		"pubsublite: partition count must be greater than zero",
-		"pubsublite: publish capacity must between 4 and 16, inclusive",
-		"pubsublite: subscribe capacity must between 4 and 32, inclusive",
-		"pubsublite: per-partition bytes must be at least 30GiB",
-		"pubsublite: retention duration must be greater than zero",
+		"reservation must be set",
+		"partition count must be greater than zero",
+		"publish capacity must between 4 and 16, inclusive",
+		"subscribe capacity must between 4 and 32, inclusive",
+		"per-partition bytes must be at least 30GiB",
+		"retention duration must be greater than zero",
 	}, "\n"))
 
 	creator, err := manager.NewTopicCreator(TopicCreatorConfig{
@@ -67,6 +67,9 @@ func TestManagerNewTopicCreator(t *testing.T) {
 }
 
 func TestTopicCreatorCreateTopics(t *testing.T) {
+	expectedTopicID := "name_space-topic_name"
+	expectedReservationPath := "projects/project/locations/region-1/reservations/name_space-reservation_name"
+
 	server, commonConfig := newTestAdminAndMetricService(t)
 	core, observedLogs := observer.New(zapcore.DebugLevel)
 	commonConfig.Logger = zap.New(core)
@@ -93,7 +96,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "projects/project/locations/region-1", server.createTopicRequest.Parent)
-	assert.Equal(t, "topic_name", server.createTopicRequest.TopicId)
+	assert.Equal(t, expectedTopicID, server.createTopicRequest.TopicId)
 	assert.Equal(t, &pubsublitepb.Topic_PartitionConfig{
 		Count: 123,
 		Dimension: &pubsublitepb.Topic_PartitionConfig_Capacity_{
@@ -108,7 +111,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 		Period:            durationpb.New(time.Hour),
 	}, server.createTopicRequest.Topic.RetentionConfig)
 	assert.Equal(t, &pubsublitepb.Topic_ReservationConfig{
-		ThroughputReservation: "projects/project/locations/region-1/reservations/reservation_name",
+		ThroughputReservation: expectedReservationPath,
 	}, server.createTopicRequest.Topic.ReservationConfig)
 
 	errorInfo, err := anypb.New(&errdetails.ErrorInfo{Reason: "RESOURCE_ALREADY_EXISTS"})
@@ -130,10 +133,14 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 
 	assert.Equal(t, []observer.LoggedEntry{{
 		Entry: zapcore.Entry{
-			Level:   zapcore.InfoLevel,
-			Message: "created pubsublite topic",
+			Level:      zapcore.InfoLevel,
+			LoggerName: "pubsublite",
+			Message:    "created pubsublite topic",
 		},
 		Context: []zapcore.Field{
+			zap.String("region", "region-1"),
+			zap.String("project", "project"),
+			zap.String("namespace", "name_space"),
 			zap.String("topic", "topic_name"),
 			zap.String("reservation", "reservation_name"),
 			zap.Int("partition_count", 123),
@@ -144,10 +151,14 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 		},
 	}, {
 		Entry: zapcore.Entry{
-			Level:   zapcore.DebugLevel,
-			Message: "pubsublite topic already exists",
+			Level:      zapcore.DebugLevel,
+			LoggerName: "pubsublite",
+			Message:    "pubsublite topic already exists",
 		},
 		Context: []zapcore.Field{
+			zap.String("region", "region-1"),
+			zap.String("project", "project"),
+			zap.String("namespace", "name_space"),
 			zap.String("topic", "topic_name"),
 		},
 	}}, observedLogs.AllUntimed())


### PR DESCRIPTION
If CommonConfig.Namespace is non-empty, a prefix (filter) will be added to all namespaces, topics, and subscriptions.
The namespace will be stripped from returned names, and will be added as a separate attribute to metrics and logs.

Part of https://github.com/elastic/apm-queue/issues/224