### PR TITLE
kafka: add topic namespacing

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -79,7 +79,7 @@ func TestCommonConfig(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, CommonConfig{
 			Brokers: []string{"broker"},
-			Logger:  zap.NewNop(),
+			Logger:  zap.NewNop().Named("kafka"),
 		}, cfg)
 	})
 
@@ -87,7 +87,7 @@ func TestCommonConfig(t *testing.T) {
 		t.Setenv("KAFKA_BROKERS", "a,b,c")
 		assertValid(t, CommonConfig{
 			Brokers: []string{"a", "b", "c"},
-			Logger:  zap.NewNop(),
+			Logger:  zap.NewNop().Named("kafka"),
 		}, CommonConfig{Logger: zap.NewNop()})
 	})
 
@@ -151,7 +151,7 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
 			t.Setenv("KAFKA_PLAINTEXT", "true")
 			assertValid(t, CommonConfig{
 				Brokers: []string{"broker"},
-				Logger:  zap.NewNop(),
+				Logger:  zap.NewNop().Named("kafka"),
 			}, CommonConfig{
 				Brokers: []string{"broker"},
 				Logger:  zap.NewNop(),
@@ -161,7 +161,7 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
 		t.Run("tls_default", func(t *testing.T) {
 			assertValid(t, CommonConfig{
 				Brokers: []string{"broker"},
-				Logger:  zap.NewNop(),
+				Logger:  zap.NewNop().Named("kafka"),
 				TLS:     &tls.Config{},
 			}, CommonConfig{
 				Brokers: []string{"broker"},
@@ -173,7 +173,7 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
 			t.Setenv("KAFKA_TLS_INSECURE", "true")
 			assertValid(t, CommonConfig{
 				Brokers: []string{"broker"},
-				Logger:  zap.NewNop(),
+				Logger:  zap.NewNop().Named("kafka"),
 				TLS:     &tls.Config{InsecureSkipVerify: true},
 			}, CommonConfig{
 				Brokers: []string{"broker"},
@@ -188,7 +188,7 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
 		assertValid(t, CommonConfig{
 			ConfigFile: configFilePath,
 			Brokers:    []string{"broker"},
-			Logger:     zap.NewNop(),
+			Logger:     zap.NewNop().Named("kafka"),
 		}, CommonConfig{
 			Brokers: []string{"broker"},
 			Logger:  zap.NewNop(),
@@ -202,7 +202,7 @@ bootstrap:
 		assertValid(t, CommonConfig{
 			ConfigFile: configFilePath,
 			Brokers:    []string{"from_file"},
-			Logger:     zap.NewNop(),
+			Logger:     zap.NewNop().Named("kafka"),
 		}, CommonConfig{
 			ConfigFile: configFilePath,
 			Brokers:    []string{"from_env"}, // ignored, file takes precedence
@@ -219,7 +219,7 @@ sasl:
 		cfg := CommonConfig{
 			ConfigFile: configFilePath,
 			Brokers:    []string{"broker"},
-			Logger:     zap.NewNop(),
+			Logger:     zap.NewNop().Named("kafka"),
 			SASL:       &mockSASL{}, // ignored, file takes precedence
 		}
 		require.NoError(t, cfg.finalize())

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -119,16 +120,18 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 	// `forceClose` is called by `Consumer.Close()` if / when the
 	// `cfg.ShutdownGracePeriod` is exceeded.
 	processingCtx, forceClose := context.WithCancelCause(context.Background())
+	namespacePrefix := cfg.namespacePrefix()
 	consumer := &consumer{
-		consumers: make(map[topicPartition]partitionConsumer),
-		processor: cfg.Processor,
-		logger:    cfg.Logger.Named("partition"),
-		delivery:  cfg.Delivery,
-		ctx:       processingCtx,
+		topicPrefix: namespacePrefix,
+		records:     make(map[topicPartition]chan []*kgo.Record),
+		processor:   cfg.Processor,
+		logger:      cfg.Logger.Named("partition"),
+		delivery:    cfg.Delivery,
+		ctx:         processingCtx,
 	}
-	topics := make([]string, 0, len(cfg.Topics))
-	for _, t := range cfg.Topics {
-		topics = append(topics, string(t))
+	topics := make([]string, len(cfg.Topics))
+	for i, topic := range cfg.Topics {
+		topics[i] = fmt.Sprintf("%s%s", consumer.topicPrefix, topic)
 	}
 	opts := []kgo.Opt{
 		// Injects the kgo.Client context as the record.Context.
@@ -275,8 +278,11 @@ func (c *Consumer) fetch(ctx, clientCtx context.Context) error {
 		c.client.AllowRebalance()
 	}
 	fetches.EachError(func(t string, p int32, err error) {
-		c.cfg.Logger.Error("consumer fetches returned error",
-			zap.Error(err), zap.String("topic", t), zap.Int32("partition", p),
+		c.cfg.Logger.Error(
+			"consumer fetches returned error",
+			zap.Error(err),
+			zap.String("topic", strings.TrimPrefix(t, c.consumer.topicPrefix)),
+			zap.Int32("partition", p),
 		)
 	})
 	c.consumer.processFetch(ctx, fetches)
@@ -295,12 +301,13 @@ func (c *Consumer) Healthy(ctx context.Context) error {
 // consumer wraps partitionConsumers and exposes the necessary callbacks
 // to use when partitions are reassigned.
 type consumer struct {
-	mu        sync.RWMutex
-	wg        sync.WaitGroup
-	consumers map[topicPartition]partitionConsumer
-	processor apmqueue.Processor
-	logger    *zap.Logger
-	delivery  apmqueue.DeliveryType
+	mu          sync.RWMutex
+	wg          sync.WaitGroup
+	topicPrefix string
+	records     map[topicPartition]chan []*kgo.Record
+	processor   apmqueue.Processor
+	logger      *zap.Logger
+	delivery    apmqueue.DeliveryType
 	// ctx contains the graceful cancellation context that is passed to the
 	// partition consumers.
 	ctx context.Context
@@ -319,19 +326,12 @@ func (c *consumer) assigned(_ context.Context, client *kgo.Client, assigned map[
 	for topic, partitions := range assigned {
 		for _, partition := range partitions {
 			c.wg.Add(1)
-			pc := partitionConsumer{
-				records:   make(chan []*kgo.Record),
-				processor: c.processor,
-				logger:    c.logger,
-				client:    client,
-				delivery:  c.delivery,
-			}
+			records := make(chan []*kgo.Record)
+			c.records[topicPartition{topic: topic, partition: partition}] = records
 			go func(topic string, partition int32) {
 				defer c.wg.Done()
-				pc.consume(c.ctx, topic, partition)
+				c.consumeTopicPartition(client, records, topic, partition)
 			}(topic, partition)
-			tp := topicPartition{partition: partition, topic: topic}
-			c.consumers[tp] = pc
 		}
 	}
 }
@@ -344,15 +344,12 @@ func (c *consumer) assigned(_ context.Context, client *kgo.Client, assigned map[
 func (c *consumer) lost(_ context.Context, _ *kgo.Client, lost map[string][]int32) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if len(c.consumers) == 0 {
-		return // When consumer.close() has been called.
-	}
 	for topic, partitions := range lost {
 		for _, partition := range partitions {
 			tp := topicPartition{topic: topic, partition: partition}
-			if pc, ok := c.consumers[tp]; ok {
-				delete(c.consumers, tp)
-				close(pc.records)
+			if records, ok := c.records[tp]; ok {
+				delete(c.records, tp)
+				close(records)
 			}
 		}
 	}
@@ -366,9 +363,9 @@ func (c *consumer) lost(_ context.Context, _ *kgo.Client, lost map[string][]int3
 func (c *consumer) close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for tp, pc := range c.consumers {
-		delete(c.consumers, tp)
-		close(pc.records)
+	for tp, records := range c.records {
+		delete(c.records, tp)
+		close(records)
 	}
 	c.wg.Wait()
 }
@@ -389,8 +386,7 @@ func (c *consumer) processFetch(ctx context.Context, fetches kgo.Fetches) {
 		if len(ftp.Records) == 0 {
 			return
 		}
-		tp := topicPartition{topic: ftp.Topic, partition: ftp.Partition}
-		pc, ok := c.consumers[tp]
+		records, ok := c.records[topicPartition{topic: ftp.Topic, partition: ftp.Partition}]
 		if !ok {
 			// NOTE(marclop) While possible, this is unlikely to happen given the
 			// locking that's in place in the caller.
@@ -404,7 +400,7 @@ func (c *consumer) processFetch(ctx context.Context, fetches kgo.Fetches) {
 		var err error
 		select {
 		// Send partition records to be processed by its dedicated goroutine.
-		case pc.records <- ftp.Records:
+		case records <- ftp.Records:
 			// Success.
 		case <-ctx.Done(): // Consumer.Run(ctx) context.
 			err = ctx.Err()
@@ -423,7 +419,7 @@ func (c *consumer) logWarn(err error, ftp kgo.FetchTopicPartition) {
 	c.logger.Warn(
 		"data loss: failed to send records to process after commit",
 		zap.Error(err),
-		zap.String("topic", ftp.Topic),
+		zap.String("topic", strings.TrimPrefix(ftp.Topic, c.topicPrefix)),
 		zap.Int32("partition", ftp.Partition),
 		zap.Int64("offset", ftp.HighWatermark),
 		zap.Int("records", len(ftp.Records)),
@@ -438,23 +434,18 @@ func (c *consumer) OnFetchRecordBuffered(r *kgo.Record) {
 	}
 }
 
-type partitionConsumer struct {
-	client    *kgo.Client
-	records   chan []*kgo.Record
-	processor apmqueue.Processor
-	logger    *zap.Logger
-	delivery  apmqueue.DeliveryType
-}
-
-// consume processed the records from a topic and partition. Calling consume
-// more than once will cause a panic.
-// The received context which is only canceled when the kgo.Client is closed.
-func (pc partitionConsumer) consume(ctx context.Context, topic string, partition int32) {
-	logger := pc.logger.With(
-		zap.String("topic", topic),
+// consumeTopicPartition processes the records for a topic and partition.
+func (c *consumer) consumeTopicPartition(
+	client *kgo.Client,
+	records <-chan []*kgo.Record,
+	prefixedTopic string, partition int32,
+) {
+	topic := apmqueue.Topic(strings.TrimPrefix(prefixedTopic, c.topicPrefix))
+	logger := c.logger.With(
+		zap.String("topic", string(topic)),
 		zap.Int32("partition", partition),
 	)
-	for records := range pc.records {
+	for records := range records {
 		// Store the last processed record. Default to -1 for cases where
 		// only the first record is received.
 		last := -1
@@ -465,19 +456,19 @@ func (pc partitionConsumer) consume(ctx context.Context, topic string, partition
 			}
 			processCtx := queuecontext.WithMetadata(msg.Context, meta)
 			record := apmqueue.Record{
-				Topic:       apmqueue.Topic(topic),
+				Topic:       topic,
 				OrderingKey: msg.Key,
 				Value:       msg.Value,
 			}
 			// If a record can't be processed, no retries are attempted and it
 			// may be lost. https://github.com/elastic/apm-queue/issues/118.
-			if err := pc.processor.Process(processCtx, record); err != nil {
+			if err := c.processor.Process(processCtx, record); err != nil {
 				logger.Error("data loss: unable to process event",
 					zap.Error(err),
 					zap.Int64("offset", msg.Offset),
 					zap.Any("headers", meta),
 				)
-				switch pc.delivery {
+				switch c.delivery {
 				case apmqueue.AtLeastOnceDeliveryType:
 					continue
 				}
@@ -486,9 +477,9 @@ func (pc partitionConsumer) consume(ctx context.Context, topic string, partition
 		}
 		// Only commit the records when at least a record has been processed when
 		// AtLeastOnceDeliveryType is set.
-		if pc.delivery == apmqueue.AtLeastOnceDeliveryType && last >= 0 {
+		if c.delivery == apmqueue.AtLeastOnceDeliveryType && last >= 0 {
 			lastRecord := records[last]
-			if err := pc.client.CommitRecords(ctx, lastRecord); err != nil {
+			if err := client.CommitRecords(c.ctx, lastRecord); err != nil {
 				logger.Error("unable to commit records",
 					zap.Error(err),
 					zap.Int64("offset", lastRecord.Offset),

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -84,15 +84,15 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 		return &kmsg.CreateTopicsResponse{
 			Version: createTopicsRequest.Version,
 			Topics: []kmsg.CreateTopicsResponseTopic{{
-				Topic:        "topic1",
+				Topic:        "name_space-topic1",
 				ErrorCode:    kerr.TopicAlreadyExists.Code,
 				ErrorMessage: &kerr.TopicAlreadyExists.Message,
 			}, {
-				Topic:        "topic2",
+				Topic:        "name_space-topic2",
 				ErrorCode:    kerr.InvalidTopicException.Code,
 				ErrorMessage: &kerr.InvalidTopicException.Message,
 			}, {
-				Topic:   "topic3",
+				Topic:   "name_space-topic3",
 				TopicID: [16]byte{123},
 			}},
 		}, nil, true
@@ -106,7 +106,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 
 	require.Len(t, createTopicsRequest.Topics, 3)
 	assert.Equal(t, []kmsg.CreateTopicsRequestTopic{{
-		Topic:             "topic1",
+		Topic:             "name_space-topic1",
 		NumPartitions:     123,
 		ReplicationFactor: -1,
 		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
@@ -114,7 +114,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 			Value: kmsg.StringPtr("123"),
 		}},
 	}, {
-		Topic:             "topic2",
+		Topic:             "name_space-topic2",
 		NumPartitions:     123,
 		ReplicationFactor: -1,
 		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
@@ -122,7 +122,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 			Value: kmsg.StringPtr("123"),
 		}},
 	}, {
-		Topic:             "topic3",
+		Topic:             "name_space-topic3",
 		NumPartitions:     123,
 		ReplicationFactor: -1,
 		Configs: []kmsg.CreateTopicsRequestTopicConfig{{
@@ -134,18 +134,22 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	matchingLogs := observedLogs.FilterFieldKey("topic")
 	assert.Equal(t, []observer.LoggedEntry{{
 		Entry: zapcore.Entry{
-			Level:   zapcore.DebugLevel,
-			Message: "kafka topic already exists",
+			Level:      zapcore.DebugLevel,
+			LoggerName: "kafka",
+			Message:    "kafka topic already exists",
 		},
 		Context: []zapcore.Field{
+			zap.String("namespace", "name_space"),
 			zap.String("topic", "topic1"),
 		},
 	}, {
 		Entry: zapcore.Entry{
-			Level:   zapcore.InfoLevel,
-			Message: "created kafka topic",
+			Level:      zapcore.InfoLevel,
+			LoggerName: "kafka",
+			Message:    "created kafka topic",
 		},
 		Context: []zapcore.Field{
+			zap.String("namespace", "name_space"),
 			zap.String("topic", "topic3"),
 			zap.Int("partition_count", 123),
 			zap.Any("topic_configs", map[string]string{


### PR DESCRIPTION
If `CommonConfig.Namespace` is non-empty, a prefix (filter) will be added to all topics. This enables the creation of a topic with the same logical name within two different namespaces. The namespace will be stripped from returned topic names, and will be added as a separate attribute to metrics and logs.

Closes https://github.com/elastic/apm-queue/issues/224