### PR TITLE
test: fix pubsub consumer goroutine leak in TestConsumerConsume

### DIFF
--- a/pubsublite/consumer_test.go
+++ b/pubsublite/consumer_test.go
@@ -125,7 +125,9 @@ func TestConsumerConsume(t *testing.T) {
 	consumer, err := NewConsumer(context.Background(), config)
 	require.NoError(t, err)
 	defer consumer.Close()
-	go consumer.Run(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go consumer.Run(ctx)
 
 	// We should receive 2 records for each subscription-partition.
 	records := make(map[subscriptionPartition][]apmqueue.Record)


### PR DESCRIPTION
goroutine leak found while investigating data race in unit tests:

```
         Goroutine 1408 in state select, with google.golang.org/grpc.(*addrConn).resetTransport on top of the stack:
        goroutine 1408 [select]:
        google.golang.org/grpc.(*addrConn).resetTransport(0xc000652600)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/clientconn.go:1368 +0x3c9
        google.golang.org/grpc.(*addrConn).connect(0xc000652600)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/clientconn.go:993 +0x96
        created by google.golang.org/grpc.(*acBalancerWrapper).Connect
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/balancer_conn_wrappers.go:398 +0x59
        [originating from goroutine 79]:
        google.golang.org/grpc.(*acBalancerWrapper).Connect(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/balancer_conn_wrappers.go:399 +0x59
        google.golang.org/grpc.(*pickfirstBalancer).UpdateSubConnState(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/pickfirst.go:181 +0x20d
        google.golang.org/grpc/internal/balancer/gracefulswitch.(*balancerWrapper).UpdateSubConnState(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/internal/balancer/gracefulswitch/gracefulswitch.go:267 +0xe9
        google.golang.org/grpc/internal/balancer/gracefulswitch.(*Balancer).UpdateSubConnState(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/internal/balancer/gracefulswitch/gracefulswitch.go:224 +0x245
        google.golang.org/grpc.(*ccBalancerWrapper).updateSubConnState.func1(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/balancer_conn_wrappers.go:143 +0x38
        google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/internal/grpcsync/callback_serializer.go:87 +0x194
        created by google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/internal/grpcsync/callback_serializer.go:55 +0x138
        [originating from goroutine 51]:
        google.golang.org/grpc/internal/grpcsync.NewCallbackSerializer(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/internal/grpcsync/callback_serializer.go:56 +0x138
        google.golang.org/grpc.newCCBalancerWrapper(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/balancer_conn_wrappers.go:86 +0x4f
        google.golang.org/grpc.(*ClientConn).exitIdleMode(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/clientconn.go:364 +0x2db
        google.golang.org/grpc.DialContext(...)
                /go/pkg/mod/google.golang.org/grpc@v1.57.0/clientconn.go:262 +0xa5e
        google.golang.org/api/transport/grpc.dial(...)
                /go/pkg/mod/google.golang.org/api@v0.135.0/transport/grpc/dial.go:204 +0xc70
        google.golang.org/api/transport/grpc.DialPool(...)
                /go/pkg/mod/google.golang.org/api@v0.135.0/transport/grpc/dial.go:107 +0x2b4
        cloud.google.com/go/pubsublite/apiv1.NewCursorClient(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/apiv1/cursor_client.go:262 +0x20c
        cloud.google.com/go/pubsublite/internal/wire.newCursorClient(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/internal/wire/rpc.go:224 +0xd1
        cloud.google.com/go/pubsublite/internal/wire.NewSubscriber(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/internal/wire/subscriber.go:602 +0x1b0
        cloud.google.com/go/pubsublite/pscompat.(*wireSubscriberFactoryImpl).New(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/pscompat/subscriber.go:112 +0x1fe
        cloud.google.com/go/pubsublite/pscompat.newSubscriberInstance(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/pscompat/subscriber.go:146 +0x1cd
        cloud.google.com/go/pubsublite/pscompat.(*SubscriberClient).Receive(...)
                /go/pkg/mod/cloud.google.com/go/pubsublite@v1.8.1/pscompat/subscriber.go:345 +0x165
        github.com/elastic/apm-queue/pubsublite.(*Consumer).Run.func1(...)
                /apm-queue/pubsublite/consumer.go:204 +0x131
        golang.org/x/sync/errgroup.(*Group).Go.func1(...)
                /go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x64
        created by golang.org/x/sync/errgroup.(*Group).Go
                /go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:72 +0xa5
        [originating from goroutine 16]:
        golang.org/x/sync/errgroup.(*Group).Go(...)
                /go/pkg/mod/golang.org/x/sync@v0.3.0/errgroup/errgroup.go:84 +0xa5
        github.com/elastic/apm-queue/pubsublite.(*Consumer).Run(...)
                /apm-queue/pubsublite/consumer.go:196 +0x1b1
        created by github.com/elastic/apm-queue/pubsublite.TestConsumerConsume
                /apm-queue/pubsublite/consumer_test.go:138 +0x335
        [originating from goroutine 12]:
        github.com/elastic/apm-queue/pubsublite.TestConsumerConsume(...)
                /apm-queue/pubsublite/consumer_test.go:141 +0x335
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        main.main(...)
                _testmain.go:81 +0x1aa
```