### PR TITLE
kafka: remove ProtocolType filter in consumer lag

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -173,14 +173,6 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 		}
 		consumerGroups := make([]string, 0, len(groups))
 		for _, group := range groups.Sorted() {
-			if group.ProtocolType != "consumer" {
-				m.cfg.Logger.Debug(
-					"ignoring non-consumer group",
-					zap.String("group", group.Group),
-					zap.String("protocol_type", group.ProtocolType),
-				)
-				continue
-			}
 			consumerGroups = append(consumerGroups, group.Group)
 		}
 		commits := m.adminClient.FetchManyOffsets(ctx, consumerGroups...)
@@ -201,7 +193,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 
 		// Calculate lag per consumer group.
 		for _, group := range groups {
-			if group.ProtocolType != "consumer" || group.Err != nil {
+			if group.Err != nil {
 				continue
 			}
 			groupLag := kadm.CalculateGroupLag(group, commits[group.Group].Fetched, endOffsets)

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -175,6 +175,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 		for _, group := range groups.Sorted() {
 			consumerGroups = append(consumerGroups, group.Group)
 		}
+		m.cfg.Logger.Debug("reporting consumer lag", zap.Strings("groups", consumerGroups))
 		commits := m.adminClient.FetchManyOffsets(ctx, consumerGroups...)
 
 		// Fetch end offsets.

--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -205,7 +205,7 @@ func TestManagerMetrics(t *testing.T) {
 						}).AppendTo(nil),
 					}},
 				},
-				{Group: "connect", ProtocolType: "connect"}, // ignored
+				{Group: "connect", ProtocolType: "connect"},
 				{
 					Group:        "consumer2",
 					ProtocolType: "consumer",
@@ -360,6 +360,7 @@ func TestManagerMetrics(t *testing.T) {
 	assert.Equal(t, &kmsg.OffsetFetchRequest{
 		Version: 8,
 		Groups: []kmsg.OffsetFetchRequestGroup{
+			{Group: "connect"},
 			{Group: "consumer1"},
 			{Group: "consumer2"},
 			{Group: "consumer3"},
@@ -373,17 +374,6 @@ func TestManagerMetrics(t *testing.T) {
 
 	matchingLogs := observedLogs.FilterFieldKey("group")
 	assert.Equal(t, []observer.LoggedEntry{{
-		Entry: zapcore.Entry{
-			Level:      zapcore.DebugLevel,
-			LoggerName: "kafka",
-			Message:    "ignoring non-consumer group",
-		},
-		Context: []zapcore.Field{
-			zap.String("namespace", "name_space"),
-			zap.String("group", "connect"),
-			zap.String("protocol_type", "connect"),
-		},
-	}, {
 		Entry: zapcore.Entry{
 			Level:      zapcore.WarnLevel,
 			LoggerName: "kafka",


### PR DESCRIPTION
We specify the consumer group name, so there's no need to also filter on the ProtocolType.

(@marclop noticed in some cases, possibly just with redpanda, that ProtocolType was empty.)