### PR TITLE
kafka: change metrics (producer.messages.count)

### DIFF
--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -18,8 +18,6 @@
 package kafka
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -36,37 +34,19 @@ const (
 
 	unitCount = "1"
 
-	msgProducedKey = "producer.messages.produced"
-	msgErroredKey  = "producer.messages.errored"
-	msgFetchedKey  = "consumer.messages.fetched"
-	msgDelayKey    = "consumer.messages.delay"
+	msgFetchedKey = "consumer.messages.fetched"
+	msgDelayKey   = "consumer.messages.delay"
 )
 
 type metricHooks struct {
-	namespace       string
-	topicPrefix     string
-	messageProduced metric.Int64Counter
-	messageErrored  metric.Int64Counter
-	messageFetched  metric.Int64Counter
-	messageDelay    metric.Float64Histogram
+	namespace      string
+	topicPrefix    string
+	messageFetched metric.Int64Counter
+	messageDelay   metric.Float64Histogram
 }
 
 func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string) (*metricHooks, error) {
 	m := mp.Meter(instrumentName)
-	messageProducedCounter, err := m.Int64Counter(msgProducedKey,
-		metric.WithDescription("The number of messages produced"),
-		metric.WithUnit(unitCount),
-	)
-	if err != nil {
-		return nil, formatMetricError(msgProducedKey, err)
-	}
-	messageErroredCounter, err := m.Int64Counter(msgErroredKey,
-		metric.WithDescription("The number of messages that failed to be produced"),
-		metric.WithUnit(unitCount),
-	)
-	if err != nil {
-		return nil, formatMetricError(msgErroredKey, err)
-	}
 	messageFetchedCounter, err := m.Int64Counter(msgFetchedKey,
 		metric.WithDescription("The number of messages that were fetched from a kafka topic"),
 		metric.WithUnit(unitCount),
@@ -86,9 +66,6 @@ func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string) (*metri
 	return &metricHooks{
 		namespace:   namespace,
 		topicPrefix: topicPrefix,
-		// Producer
-		messageProduced: messageProducedCounter,
-		messageErrored:  messageErroredCounter,
 		// Consumer
 		messageFetched: messageFetchedCounter,
 		messageDelay:   messageDelayHistogram,
@@ -111,21 +88,8 @@ func (h *metricHooks) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 	}
 
 	if err != nil {
-		errorType := attribute.String("error", "other")
-		if errors.Is(err, context.DeadlineExceeded) {
-			errorType = attribute.String("error", "timeout")
-		} else if errors.Is(err, context.Canceled) {
-			errorType = attribute.String("error", "canceled")
-		}
-
-		h.messageErrored.Add(context.Background(), 1,
-			metric.WithAttributes(append(attrs, errorType)...),
-		)
 		return
 	}
-	h.messageProduced.Add(context.Background(), 1,
-		metric.WithAttributes(attrs...),
-	)
 }
 
 // OnFetchRecordUnbuffered records the number of fetched messages.

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -65,8 +65,8 @@ func TestProducerMetrics(t *testing.T) {
 	t.Run("DeadlineExceeded", func(t *testing.T) {
 		producer, rdr := setupTestProducer(t)
 		want := metricdata.Metrics{
-			Name:        "producer.messages.errored",
-			Description: "The number of messages that failed to be produced",
+			Name:        "producer.messages.count",
+			Description: "The number of messages produced",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
 				Temporality: metricdata.CumulativeTemporality,
@@ -74,6 +74,7 @@ func TestProducerMetrics(t *testing.T) {
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
 						Value: 3, Attributes: attribute.NewSet(
+							attribute.String("outcome", "failure"),
 							attribute.String("error", "timeout"),
 							attribute.String("namespace", "name_space"),
 							semconv.MessagingSystem("kafka"),
@@ -91,8 +92,8 @@ func TestProducerMetrics(t *testing.T) {
 	t.Run("ContextCanceled", func(t *testing.T) {
 		producer, rdr := setupTestProducer(t)
 		want := metricdata.Metrics{
-			Name:        "producer.messages.errored",
-			Description: "The number of messages that failed to be produced",
+			Name:        "producer.messages.count",
+			Description: "The number of messages produced",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
 				Temporality: metricdata.CumulativeTemporality,
@@ -100,6 +101,7 @@ func TestProducerMetrics(t *testing.T) {
 				DataPoints: []metricdata.DataPoint[int64]{
 					{
 						Value: 3, Attributes: attribute.NewSet(
+							attribute.String("outcome", "failure"),
 							attribute.String("error", "canceled"),
 							attribute.String("namespace", "name_space"),
 							semconv.MessagingSystem("kafka"),
@@ -117,8 +119,8 @@ func TestProducerMetrics(t *testing.T) {
 	t.Run("Other", func(t *testing.T) {
 		producer, rdr := setupTestProducer(t)
 		want := metricdata.Metrics{
-			Name:        "producer.messages.errored",
-			Description: "The number of messages that failed to be produced",
+			Name:        "producer.messages.count",
+			Description: "The number of messages produced",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
 				Temporality: metricdata.CumulativeTemporality,
@@ -127,6 +129,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3,
 						Attributes: attribute.NewSet(
+							attribute.String("outcome", "failure"),
 							attribute.String("error", "other"),
 							attribute.String("namespace", "name_space"),
 							semconv.MessagingSystem("kafka"),
@@ -143,7 +146,7 @@ func TestProducerMetrics(t *testing.T) {
 	t.Run("Produced", func(t *testing.T) {
 		producer, rdr := setupTestProducer(t)
 		want := metricdata.Metrics{
-			Name:        "producer.messages.produced",
+			Name:        "producer.messages.count",
 			Description: "The number of messages produced",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -153,6 +156,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3,
 						Attributes: attribute.NewSet(
+							attribute.String("outcome", "success"),
 							attribute.String("namespace", "name_space"),
 							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),
@@ -167,7 +171,7 @@ func TestProducerMetrics(t *testing.T) {
 	t.Run("ProducedWithHeaders", func(t *testing.T) {
 		producer, rdr := setupTestProducer(t)
 		want := metricdata.Metrics{
-			Name:        "producer.messages.produced",
+			Name:        "producer.messages.count",
 			Description: "The number of messages produced",
 			Unit:        "1",
 			Data: metricdata.Sum[int64]{
@@ -177,6 +181,7 @@ func TestProducerMetrics(t *testing.T) {
 					{
 						Value: 3,
 						Attributes: attribute.NewSet(
+							attribute.String("outcome", "success"),
 							attribute.String("namespace", "name_space"),
 							semconv.MessagingSystem("kafka"),
 							semconv.MessagingDestinationName("default-topic"),


### PR DESCRIPTION
Add Kafka `producer.messages.count` metric. This metric counts all produced
messages and uses `outcome=success|failure` dimension to distinguish
between messages that failed or have been successfully produced.

`error=other|timeout|cancelled` dimension is used to identify the failure
reason.

Remove `producer.messages.produced` and `producer.messages.errored`
Kafka metrics as both are replaced by `producer.messages.count`.

Part of https://github.com/elastic/apm-queue/issues/251

