### PR TITLE
test: refactor unit tests to reduce flakyness

### DIFF
--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -118,7 +118,8 @@ func TestNewProducerBasic(t *testing.T) {
 					Namespace:      "name_space",
 					TracerProvider: tp,
 				},
-				Sync: sync,
+				Sync:               sync,
+				MaxBufferedRecords: 0,
 			})
 
 			ctx := queuecontext.WithMetadata(context.Background(), map[string]string{"a": "b", "c": "d"})
@@ -138,11 +139,11 @@ func TestNewProducerBasic(t *testing.T) {
 				// Cancel the context before calling Produce
 				ctxCancelled, cancelProduce := context.WithCancel(ctx)
 				cancelProduce()
-				producer.Produce(ctxCancelled, batch...)
+				require.NoError(t, producer.Produce(ctxCancelled, batch...))
 			} else {
 				produceCtx, cancel := context.WithTimeout(ctx, time.Second)
 				defer cancel()
-				producer.Produce(produceCtx, batch...)
+				require.NoError(t, producer.Produce(produceCtx, batch...))
 			}
 
 			var actual []apmqueue.Record


### PR DESCRIPTION
Tested locally by running tests with `-count=<big>` and was able to reduce flakyness significantly.

## Changes:

### TestConsumerDelivery:

Instead of waiting for `consumer.Close` to complete before proceeding, call `consumer.Close` from the same goroutine and wait for `consumer.Run` to exit. This ensure that the first consumer has exited.

Call the `cancel` function inside the processor to avoid a small race  between the time the processor finishes and the time `cancel` was called.

### TestNewProducerBasic

Set `MaxBufferedRecords` to 0 to avoid context cancelled because the consumer is waiting on the buffered records. (another option would be to close the producer to force a flush).
