### PR TITLE
kafka: Remove record-level tracing

### DIFF
--- a/kafka/common.go
+++ b/kafka/common.go
@@ -271,7 +271,8 @@ func (cfg *CommonConfig) newClient(additionalOpts ...kgo.Opt) (*kgo.Client, erro
 	opts = append(opts, additionalOpts...)
 	if !cfg.DisableTelemetry {
 		kotelService := kotel.NewKotel(
-			kotel.WithTracer(kotel.NewTracer(kotel.TracerProvider(cfg.tracerProvider()))),
+			// NOTE(marclop) do not trace on a per-record basis.
+			// kotel.WithTracer(kotel.NewTracer(kotel.TracerProvider(cfg.tracerProvider()))),
 			kotel.WithMeter(kotel.NewMeter(kotel.MeterProvider(cfg.meterProvider()))),
 		)
 		metricHooks, err := newKgoHooks(cfg.meterProvider(), cfg.Namespace, cfg.namespacePrefix())

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -172,7 +172,6 @@ func TestConsumerInstrumentation(t *testing.T) {
 		&kgo.Record{Topic: "name_space-topic", Value: event.Value},
 	)
 	consumer := newConsumer(t, cfg)
-	spanCount := len(exp.GetSpans())
 	go consumer.Run(context.Background())
 
 	select {
@@ -180,7 +179,6 @@ func TestConsumerInstrumentation(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out while waiting for record to be processed.")
 	}
-	assert.Len(t, exp.GetSpans(), spanCount+1)
 }
 
 func TestConsumerDelivery(t *testing.T) {


### PR DESCRIPTION
To reduce memory usage of applications that use this library, remove the usage of `kotel` tracing hooks to avoid creating a span for each event that is either read or written to Kafka.

Closes #300