### PR TITLE
kafka: manager: List topics before creating them

### DIFF
--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -207,7 +207,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 			)
 		}
 	}
-	if len(c.topicConfigs) > 0 {
+	if len(existingTopics) > 0 && len(c.topicConfigs) > 0 {
 		alterCfg := make([]kadm.AlterConfig, 0, len(c.topicConfigs))
 		for k, v := range c.topicConfigs {
 			alterCfg = append(alterCfg, kadm.AlterConfig{Name: k, Value: v})

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -109,10 +109,11 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		return fmt.Errorf("failed to list kafka topics: %w", err)
 	}
 
-	// Build two lists, one for the topics that haven't been created yet, and
-	// another one that can be used to update a topic's partitions.
+	// missingTopics contains topics which need to be created.
 	missingTopics := make([]string, 0, len(topicNames))
+	// updatePartitions contains topics which partitions' need to be updated.
 	updatePartitions := make([]string, 0, len(topicNames))
+	// existingTopics contains the existing topics, used by AlterTopicConfigs.
 	existingTopics := make([]string, 0, len(topicNames))
 	for _, wantTopic := range topicNames {
 		if !existing.Has(wantTopic) {

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -194,7 +194,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	// Ensure only the existing topic config is updated since it already exists.
 	assert.Len(t, alterConfigsRequest.Resources, 1)
 	assert.Equal(t, []kmsg.IncrementalAlterConfigsRequestResource{{
-		ResourceType: 2,
+		ResourceType: kmsg.ConfigResourceTypeTopic,
 		ResourceName: "name_space-topic0",
 		Configs: []kmsg.IncrementalAlterConfigsRequestResourceConfig{{
 			Name:  "retention.ms",


### PR DESCRIPTION
Updates the manager `CreateTopics` method to only issue the CreateTopics call if the topics don't exist in Kafka, preventing undesirable errors from being returned and logged.