### PR TITLE
fix: always use context.Background() when updating metrics

### DIFF
--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -135,7 +135,7 @@ func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
 		attrs = append(attrs, attribute.String("namespace", h.namespace))
 	}
 
-	h.messageFetched.Add(r.Context, 1,
+	h.messageFetched.Add(context.Background(), 1,
 		metric.WithAttributes(attrs...),
 	)
 
@@ -144,7 +144,7 @@ func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, _ bool) {
 	span.SetAttributes(
 		attribute.Float64(msgDelayKey, delay),
 	)
-	h.messageDelay.Record(r.Context, delay, metric.WithAttributes(
+	h.messageDelay.Record(context.Background(), delay, metric.WithAttributes(
 		attrs...,
 	))
 }

--- a/pubsublite/internal/telemetry/consumer.go
+++ b/pubsublite/internal/telemetry/consumer.go
@@ -108,7 +108,7 @@ func Consumer(
 			}
 		}
 
-		metrics.fetched.Add(ctx, 1, metric.WithAttributes(
+		metrics.fetched.Add(context.Background(), 1, metric.WithAttributes(
 			attrs...,
 		))
 
@@ -130,7 +130,7 @@ func Consumer(
 		span.SetAttributes(
 			attribute.Float64(msgDelayKey, delay),
 		)
-		metrics.queuedDelay.Record(ctx, delay, metric.WithAttributes(
+		metrics.queuedDelay.Record(context.Background(), delay, metric.WithAttributes(
 			attrs...,
 		))
 

--- a/pubsublite/internal/telemetry/publisher.go
+++ b/pubsublite/internal/telemetry/publisher.go
@@ -117,12 +117,12 @@ func (p *Producer) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.P
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			p.metrics.errored.Add(ctx, 1, metric.WithAttributes(
+			p.metrics.errored.Add(context.Background(), 1, metric.WithAttributes(
 				attrs...,
 			))
 		} else {
 			span.SetStatus(codes.Ok, "success")
-			p.metrics.produced.Add(ctx, 1, metric.WithAttributes(
+			p.metrics.produced.Add(context.Background(), 1, metric.WithAttributes(
 				attrs...,
 			))
 		}


### PR DESCRIPTION
The request context can be canceled or timed out. We should always use the background context when updating metrics to ensure metrics are reported correctly.