### PR TITLE
kafka: Add topic creation & deletion metrics

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -132,12 +132,17 @@ func (m *Manager) DeleteTopics(ctx context.Context, topics ...apmqueue.Topic) er
 				deleteErrors = append(deleteErrors,
 					fmt.Errorf("failed to delete topic %q: %w", topic, err),
 				)
+				m.deleted.Add(context.Background(), 1, metric.WithAttributes(
+					semconv.MessagingSystemKey.String("kafka"),
+					attribute.String("outcome", "failure"),
+				))
 			}
 			continue
 		}
 		m.deleted.Add(context.Background(), 1, metric.WithAttributes(
-			semconv.MessagingSystemKey.String("kafka")),
-		)
+			semconv.MessagingSystemKey.String("kafka"),
+			attribute.String("outcome", "success"),
+		))
 		logger.Info("deleted kafka topic")
 	}
 	return errors.Join(deleteErrors...)

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -77,7 +77,7 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	}
 	meter := cfg.MeterProvider.Meter("github.com/elastic/apm-queue/kafka")
 	deleted, err := meter.Int64Counter("topics.deleted.count",
-		metric.WithDescription("The number deleted topics"),
+		metric.WithDescription("The number of deleted topics"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating 'topics.deleted.count' metric: %w", err)

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -59,6 +60,7 @@ type Manager struct {
 	client      *kgo.Client
 	adminClient *kadm.Client
 	tracer      trace.Tracer
+	deleted     metric.Int64Counter
 }
 
 // NewManager returns a new Manager with the given config.
@@ -70,13 +72,23 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed creating kafka client: %w", err)
 	}
-	m := &Manager{
+	if cfg.MeterProvider == nil {
+		cfg.MeterProvider = otel.GetMeterProvider()
+	}
+	meter := cfg.MeterProvider.Meter("github.com/elastic/apm-queue/kafka")
+	deleted, err := meter.Int64Counter("topics.deleted.count",
+		metric.WithDescription("The number deleted topics"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating 'topics.deleted.count' metric: %w", err)
+	}
+	return &Manager{
 		cfg:         cfg,
 		client:      client,
 		adminClient: kadm.NewClient(client),
 		tracer:      cfg.tracerProvider().Tracer("kafka"),
-	}
-	return m, nil
+		deleted:     deleted,
+	}, nil
 }
 
 // Close closes the manager's resources, including its connections to the
@@ -123,6 +135,9 @@ func (m *Manager) DeleteTopics(ctx context.Context, topics ...apmqueue.Topic) er
 			}
 			continue
 		}
+		m.deleted.Add(context.Background(), 1, metric.WithAttributes(
+			semconv.MessagingSystemKey.String("kafka")),
+		)
 		logger.Info("deleted kafka topic")
 	}
 	return errors.Join(deleteErrors...)

--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -153,7 +153,11 @@ func TestManagerDeleteTopics(t *testing.T) {
 	}
 	// Ensure only 1 topic was deleted, which also matches the number of spans.
 	assert.Equal(t, metrictest.Int64Metrics{
-		{Name: "topics.deleted.count"}: {{K: "messaging.system", V: "kafka"}: 1},
+		{Name: "topics.deleted.count"}: {
+			{K: "messaging.system", V: "kafka"}: 2,
+			{K: "outcome", V: "failure"}:        1,
+			{K: "outcome", V: "success"}:        1,
+		},
 	}, metrictest.GatherInt64Metric(metrics))
 }
 

--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -42,6 +42,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	apmqueue "github.com/elastic/apm-queue"
+	"github.com/elastic/apm-queue/metrictest"
 )
 
 func TestNewManager(t *testing.T) {
@@ -60,10 +61,12 @@ func TestManagerDeleteTopics(t *testing.T) {
 	)
 	defer tp.Shutdown(context.Background())
 
+	mt := metrictest.New()
 	cluster, commonConfig := newFakeCluster(t)
 	core, observedLogs := observer.New(zapcore.DebugLevel)
 	commonConfig.Logger = zap.New(core)
 	commonConfig.TracerProvider = tp
+	commonConfig.MeterProvider = mt.MeterProvider
 	m, err := NewManager(ManagerConfig{CommonConfig: commonConfig})
 	require.NoError(t, err)
 	t.Cleanup(func() { m.Close() })
@@ -138,6 +141,20 @@ func TestManagerDeleteTopics(t *testing.T) {
 			"INVALID_TOPIC_EXCEPTION: The request attempted to perform an operation on an invalid topic.",
 		),
 	}, spans[0].Events[0].Attributes)
+	rm, err := mt.Collect(context.Background())
+	require.NoError(t, err)
+	// Filter all other kafka metrics.
+	var metrics []metricdata.Metrics
+	for _, sm := range rm.ScopeMetrics {
+		if sm.Scope.Name == "github.com/elastic/apm-queue/kafka" {
+			metrics = sm.Metrics
+			break
+		}
+	}
+	// Ensure only 1 topic was deleted, which also matches the number of spans.
+	assert.Equal(t, metrictest.Int64Metrics{
+		{Name: "topics.deleted.count"}: {{K: "messaging.system", V: "kafka"}: 1},
+	}, metrictest.GatherInt64Metric(metrics))
 }
 
 func TestManagerMetrics(t *testing.T) {

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -83,7 +83,7 @@ func (m *Manager) NewTopicCreator(cfg TopicCreatorConfig) (*TopicCreator, error)
 	}
 	meter := cfg.MeterProvider.Meter("github.com/elastic/apm-queue/kafka")
 	created, err := meter.Int64Counter("topics.created.count",
-		metric.WithDescription("The number created topics"),
+		metric.WithDescription("The number of created topics"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating 'topics.created.count' metric: %w", err)

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -326,6 +326,10 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	}
 	// Ensure only 1 topic was created, which also matches the number of spans.
 	assert.Equal(t, metrictest.Int64Metrics{
-		{Name: "topics.created.count"}: {{K: "messaging.system", V: "kafka"}: 1},
+		{Name: "topics.created.count"}: {
+			{K: "messaging.system", V: "kafka"}: 2,
+			{K: "outcome", V: "failure"}:        1,
+			{K: "outcome", V: "success"}:        1,
+		},
 	}, metrictest.GatherInt64Metric(metrics))
 }

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/apm-queue/metrictest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +38,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/elastic/apm-queue/metrictest"
 )
 
 func TestNewTopicCreator(t *testing.T) {

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/apm-queue/metrictest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kmsg"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -63,6 +65,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	)
 	defer tp.Shutdown(context.Background())
 
+	mt := metrictest.New()
 	cluster, commonConfig := newFakeCluster(t)
 	core, observedLogs := observer.New(zapcore.DebugLevel)
 	commonConfig.Logger = zap.New(core)
@@ -76,6 +79,7 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 		TopicConfigs: map[string]string{
 			"retention.ms": "123",
 		},
+		MeterProvider: mt.MeterProvider,
 	})
 	require.NoError(t, err)
 
@@ -309,4 +313,19 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	assert.Equal(t, []attribute.KeyValue{
 		semconv.MessagingDestinationKey.String("topic4"),
 	}, spans[0].Events[2].Attributes)
+
+	rm, err := mt.Collect(context.Background())
+	require.NoError(t, err)
+	// Filter all other kafka metrics.
+	var metrics []metricdata.Metrics
+	for _, sm := range rm.ScopeMetrics {
+		if sm.Scope.Name == "github.com/elastic/apm-queue/kafka" {
+			metrics = sm.Metrics
+			break
+		}
+	}
+	// Ensure only 1 topic was created, which also matches the number of spans.
+	assert.Equal(t, metrictest.Int64Metrics{
+		{Name: "topics.created.count"}: {{K: "messaging.system", V: "kafka"}: 1},
+	}, metrictest.GatherInt64Metric(metrics))
 }

--- a/metrictest/metric.go
+++ b/metrictest/metric.go
@@ -1,0 +1,91 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package metrictest provides helpers for metric testing.
+package metrictest
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// TestMetric returns all the necessary for tests.
+type TestMetric struct {
+	Reader        sdkmetric.Reader
+	MeterProvider *sdkmetric.MeterProvider
+	Meter         metric.Meter
+}
+
+// New creates a manual reader, meter provider and a meter from it.
+func New() (tm TestMetric) {
+	tm.Reader = sdkmetric.NewManualReader(sdkmetric.WithTemporalitySelector(
+		func(ik sdkmetric.InstrumentKind) metricdata.Temporality {
+			return metricdata.DeltaTemporality
+		},
+	))
+	tm.MeterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(tm.Reader))
+	tm.Meter = tm.MeterProvider.Meter("test")
+	return
+}
+
+// Collect returns the metrics from the reader.
+func (tm TestMetric) Collect(ctx context.Context) (
+	rm metricdata.ResourceMetrics, err error,
+) {
+	err = tm.Reader.Collect(ctx, &rm)
+	return
+}
+
+// Key holds the key for the metric name and unit.
+type Key struct{ Name, Unit string }
+
+// KV holds the key and value for a dimension
+type KV struct{ K, V string }
+
+// Int64Metrics defines a metric to dimension mapping for int64 metrics.
+type Int64Metrics map[Key]Dimension
+
+// Dimension defines a generic dimension.
+type Dimension map[KV]int64
+
+// GatherInt64Metric gathers the observed int64 metrics grouped by dimension.
+func GatherInt64Metric(ms []metricdata.Metrics) Int64Metrics {
+	observed := Int64Metrics{}
+	for _, m := range ms {
+		valueMap := Dimension{}
+		switch data := m.Data.(type) {
+		case metricdata.Sum[int64]:
+			for _, dp := range data.DataPoints {
+				if dp.Attributes.Len() == 0 {
+					valueMap[KV{}] += int64(dp.Value)
+				}
+				iter := dp.Attributes.Iter()
+				for iter.Next() {
+					attr := iter.Attribute()
+					valueMap[KV{string(attr.Key), attr.Value.Emit()}] += int64(dp.Value)
+				}
+			}
+		default:
+			continue
+		}
+		observed[Key{Name: m.Name, Unit: m.Unit}] = valueMap
+	}
+	return observed
+}


### PR DESCRIPTION
Updates the `kafka` package to record the number of topics that have been created and deleted, improving the overall observability.