### PR TITLE
kafka: Add `topic` to create/delete metrics

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -135,6 +135,7 @@ func (m *Manager) DeleteTopics(ctx context.Context, topics ...apmqueue.Topic) er
 				m.deleted.Add(context.Background(), 1, metric.WithAttributes(
 					semconv.MessagingSystemKey.String("kafka"),
 					attribute.String("outcome", "failure"),
+					attribute.String("topic", topic),
 				))
 			}
 			continue
@@ -142,6 +143,7 @@ func (m *Manager) DeleteTopics(ctx context.Context, topics ...apmqueue.Topic) er
 		m.deleted.Add(context.Background(), 1, metric.WithAttributes(
 			semconv.MessagingSystemKey.String("kafka"),
 			attribute.String("outcome", "success"),
+			attribute.String("topic", topic),
 		))
 		logger.Info("deleted kafka topic")
 	}

--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -154,9 +154,11 @@ func TestManagerDeleteTopics(t *testing.T) {
 	// Ensure only 1 topic was deleted, which also matches the number of spans.
 	assert.Equal(t, metrictest.Int64Metrics{
 		{Name: "topics.deleted.count"}: {
+			{K: "topic", V: "topic2"}:           1,
 			{K: "messaging.system", V: "kafka"}: 2,
 			{K: "outcome", V: "failure"}:        1,
 			{K: "outcome", V: "success"}:        1,
+			{K: "topic", V: "topic3"}:           1,
 		},
 	}, metrictest.GatherInt64Metric(metrics))
 }

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -187,6 +187,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 				c.created.Add(context.Background(), 1, metric.WithAttributes(
 					semconv.MessagingSystemKey.String("kafka"),
 					attribute.String("outcome", "failure"),
+					attribute.String("topic", topicName),
 				))
 			}
 			continue
@@ -194,6 +195,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		c.created.Add(context.Background(), 1, metric.WithAttributes(
 			semconv.MessagingSystemKey.String("kafka"),
 			attribute.String("outcome", "success"),
+			attribute.String("topic", topicName),
 		))
 		logger.Info("created kafka topic", zap.String("topic", topicName))
 	}

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -328,6 +328,8 @@ func TestTopicCreatorCreateTopics(t *testing.T) {
 	// Ensure only 1 topic was created, which also matches the number of spans.
 	assert.Equal(t, metrictest.Int64Metrics{
 		{Name: "topics.created.count"}: {
+			{K: "topic", V: "topic2"}:           1,
+			{K: "topic", V: "topic3"}:           1,
 			{K: "messaging.system", V: "kafka"}: 2,
 			{K: "outcome", V: "failure"}:        1,
 			{K: "outcome", V: "success"}:        1,


### PR DESCRIPTION
Adds a new `topic` dimension to the `create`/`delete` metrics.