### PR TITLE
ci: skip system-test for dependabot

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # This step is skipped if the pull request is from a forked repository.
+      # This step is skipped if the pull request is from a forked repository or dependabot
       # In that case the job just creates a green status check on the pull request.
-      - if: github.event.pull_request.head.repo.full_name == github.repository
+      - if: |
+          github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
         uses: ./.github/actions/system-test
         with:
           vault-url: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
dependabot does not have access to GH secrets.