### PR TITLE
ci: exclude dependabot push but use pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: ci
-on: ["push", "pull_request"]
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
There is no need to run the same CI pipeline for two different events when a dependabot PR.