### PR TITLE
kafka: Remove partition consumer goroutines

### DIFF
--- a/kafka/common.go
+++ b/kafka/common.go
@@ -270,11 +270,9 @@ func (cfg *CommonConfig) newClient(additionalOpts ...kgo.Opt) (*kgo.Client, erro
 	}
 	opts = append(opts, additionalOpts...)
 	if !cfg.DisableTelemetry {
-		kotelService := kotel.NewKotel(
-			// NOTE(marclop) do not trace on a per-record basis.
-			// kotel.WithTracer(kotel.NewTracer(kotel.TracerProvider(cfg.tracerProvider()))),
-			kotel.WithMeter(kotel.NewMeter(kotel.MeterProvider(cfg.meterProvider()))),
-		)
+		kotelService := kotel.NewKotel(kotel.WithMeter(
+			kotel.NewMeter(kotel.MeterProvider(cfg.meterProvider())),
+		))
 		metricHooks, err := newKgoHooks(cfg.meterProvider(), cfg.Namespace, cfg.namespacePrefix())
 		if err != nil {
 			return nil, fmt.Errorf("kafka: failed creating kgo metrics hooks: %w", err)

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -354,6 +354,9 @@ func TestConsumerDelivery(t *testing.T) {
 			}
 
 			assert.Eventually(t, func() bool {
+				if tc.deliveryType == apmqueue.AtLeastOnceDeliveryType {
+					return int(errored.Load()) >= int(tc.errored)
+				}
 				return int(errored.Load()) == int(tc.errored)
 			}, time.Second, time.Millisecond)
 			t.Logf("got: %d events errored, %d processed, want: %d errored, %d processed",
@@ -386,7 +389,7 @@ func TestConsumerDelivery(t *testing.T) {
 			assert.Eventually(t, func() bool {
 				// Some events may or may not be processed. Assert GE.
 				return processed.Load() >= tc.processed &&
-					errored.Load() == tc.errored
+					errored.Load() >= tc.errored
 			}, 2*time.Second, time.Millisecond)
 			t.Logf("got: %d events errored, %d processed, want: %d errored, %d processed",
 				errored.Load(), processed.Load(), tc.errored, tc.processed,

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -277,13 +277,11 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 				}
 			}
 			for key, count := range memberAssignments {
-				o.ObserveInt64(assignmentMetric, count,
-					metric.WithAttributes(
-						attribute.String("group", l.Group),
-						attribute.String("topic", key.topic),
-						attribute.String("client_id", key.clientID),
-					),
-				)
+				o.ObserveInt64(assignmentMetric, count, metric.WithAttributes(
+					attribute.String("group", l.Group),
+					attribute.String("topic", key.topic),
+					attribute.String("client_id", key.clientID),
+				))
 			}
 		})
 		return nil


### PR DESCRIPTION
Removes the need for dedicated goroutines to be spun when the consumer receives its partition assignments. Instead, it uses an `errgroup.Group` with a limit of `1`, which behaves like before.

This approach's primary advantage is that it reduces the number of running goroutines, which is noticeable as the partition count increases.

Without this patch, the consumer throughput plateaued after reaching a certain throughput.