### PR TITLE
fix: handle empty group when monitoring consumer lag

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -263,6 +263,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 						continue
 					}
 					clientID := "nil"
+					// If group is in state Empty the lag.Member is nil
 					if lag.Member != nil {
 						clientID = lag.Member.ClientID
 					}


### PR DESCRIPTION
If group is in state Empty the lag.Member is nil causing a panic

```
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
	go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:405 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0004c4300, {0x0, 0x0, 0xc00014da40?})
	go.opentelemetry.io/otel/sdk@v1.24.0/trace/span.go:443 +0xa82
panic({0xfce780?, 0x1ab4470?})
	runtime/panic.go:770 +0x132
github.com/elastic/apm-queue/kafka.(*Manager).MonitorConsumerLag.func1.1({{0xc000048528, 0x11}, {0x26, 0x238a, {0xc00017bdc0, 0x38}, 0x0, {}}, {0xc000259554, 0x5}, ...})
	github.com/elastic/apm-queue@v1.0.0/kafka/manager.go:265 +0x1056
github.com/twmb/franz-go/pkg/kadm.DescribedGroupLags.Each(...)
	github.com/twmb/franz-go/pkg/kadm@v1.11.0/groups.go:1385
github.com/elastic/apm-queue/kafka.(*Manager).MonitorConsumerLag.func1({0x1301c20, 0xc00018f6c0}, {0x1300770, 0xc00042a960})
	github.com/elastic/apm-queue@v1.0.0/kafka/manager.go:224 +0x83d
go.opentelemetry.io/otel/sdk/metric.(*meter).RegisterCallback.func1({0x1301c20, 0xc00018f6c0})
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/meter.go:445 +0x55
go.opentelemetry.io/otel/sdk/metric.(*pipeline).produce(0xc0002f0090, {0x1301c20, 0xc00018f6c0}, 0xc00038f080)
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/pipeline.go:134 +0x305
go.opentelemetry.io/otel/sdk/metric.(*PeriodicReader).collect(0xc000246e60, {0x1301c20, 0xc00018f6c0}, {0x1007680?, 0xc0001490f8?}, 0xc00038f080)
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:261 +0x99
go.opentelemetry.io/otel/sdk/metric.(*PeriodicReader).Collect(0xc000246ed8?, {0x1301c20?, 0xc00018f6c0?}, 0xc0001bd140?)
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:242 +0x70
go.opentelemetry.io/otel/sdk/metric.(*PeriodicReader).collectAndExport(0xc000246e60, {0x1301bb0?, 0xc000091ea0?})
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:219 +0xaa
go.opentelemetry.io/otel/sdk/metric.(*PeriodicReader).run(0xc000246e60, {0x1301bb0, 0xc000091ea0}, 0x2540be400)
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:179 +0x1c5
go.opentelemetry.io/otel/sdk/metric.NewPeriodicReader.func2()
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:137 +0x55
created by go.opentelemetry.io/otel/sdk/metric.NewPeriodicReader in goroutine 1
	go.opentelemetry.io/otel/sdk/metric@v1.24.0/periodic_reader.go:135 +0x24a
```