### PR TITLE
telemetry: perf: Use `metric.WithAttributeSet`

### DIFF
--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -132,18 +132,22 @@ func (m *Manager) DeleteTopics(ctx context.Context, topics ...apmqueue.Topic) er
 				deleteErrors = append(deleteErrors,
 					fmt.Errorf("failed to delete topic %q: %w", topic, err),
 				)
-				m.deleted.Add(context.Background(), 1, metric.WithAttributes(
-					semconv.MessagingSystemKey.String("kafka"),
-					attribute.String("outcome", "failure"),
-					attribute.String("topic", topic),
+				m.deleted.Add(context.Background(), 1, metric.WithAttributeSet(
+					attribute.NewSet(
+						semconv.MessagingSystemKey.String("kafka"),
+						attribute.String("outcome", "failure"),
+						attribute.String("topic", topic),
+					),
 				))
 			}
 			continue
 		}
-		m.deleted.Add(context.Background(), 1, metric.WithAttributes(
-			semconv.MessagingSystemKey.String("kafka"),
-			attribute.String("outcome", "success"),
-			attribute.String("topic", topic),
+		m.deleted.Add(context.Background(), 1, metric.WithAttributeSet(
+			attribute.NewSet(
+				semconv.MessagingSystemKey.String("kafka"),
+				attribute.String("outcome", "success"),
+				attribute.String("topic", topic),
+			),
 		))
 		logger.Info("deleted kafka topic")
 	}
@@ -273,19 +277,21 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 					memberAssignments[key] = count
 					o.ObserveInt64(
 						consumerGroupLagMetric, lag.Lag,
-						metric.WithAttributes(
+						metric.WithAttributeSet(attribute.NewSet(
 							attribute.String("group", l.Group),
 							attribute.String("topic", topic),
 							attribute.Int("partition", int(partition)),
-						),
+						)),
 					)
 				}
 			}
 			for key, count := range memberAssignments {
-				o.ObserveInt64(assignmentMetric, count, metric.WithAttributes(
-					attribute.String("group", l.Group),
-					attribute.String("topic", key.topic),
-					attribute.String("client_id", key.clientID),
+				o.ObserveInt64(assignmentMetric, count, metric.WithAttributeSet(
+					attribute.NewSet(
+						attribute.String("group", l.Group),
+						attribute.String("topic", key.topic),
+						attribute.String("client_id", key.clientID),
+					),
 				))
 			}
 		})

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -115,8 +115,8 @@ func (h *metricHooks) OnProduceRecordUnbuffered(r *kgo.Record, err error) {
 		attrs = append(attrs, attribute.String("outcome", "success"))
 	}
 
-	h.messageProduced.Add(context.Background(), 1, metric.WithAttributes(
-		attrs...,
+	h.messageProduced.Add(context.Background(), 1, metric.WithAttributeSet(
+		attribute.NewSet(attrs...),
 	))
 }
 
@@ -134,7 +134,7 @@ func (h *metricHooks) OnFetchRecordUnbuffered(r *kgo.Record, polled bool) {
 		attrs = append(attrs, attribute.String("namespace", h.namespace))
 	}
 
-	attrSet := metric.WithAttributes(attrs...)
+	attrSet := metric.WithAttributeSet(attribute.NewSet(attrs...))
 	h.messageFetched.Add(context.Background(), 1, attrSet)
 	h.messageDelay.Record(context.Background(),
 		time.Since(r.Timestamp).Seconds(), attrSet,

--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -184,18 +184,22 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 				updateErrors = append(updateErrors, fmt.Errorf(
 					"failed to create topic %q: %w", topicName, err,
 				))
-				c.created.Add(context.Background(), 1, metric.WithAttributes(
-					semconv.MessagingSystemKey.String("kafka"),
-					attribute.String("outcome", "failure"),
-					attribute.String("topic", topicName),
+				c.created.Add(context.Background(), 1, metric.WithAttributeSet(
+					attribute.NewSet(
+						semconv.MessagingSystemKey.String("kafka"),
+						attribute.String("outcome", "failure"),
+						attribute.String("topic", topicName),
+					),
 				))
 			}
 			continue
 		}
-		c.created.Add(context.Background(), 1, metric.WithAttributes(
-			semconv.MessagingSystemKey.String("kafka"),
-			attribute.String("outcome", "success"),
-			attribute.String("topic", topicName),
+		c.created.Add(context.Background(), 1, metric.WithAttributeSet(
+			attribute.NewSet(
+				semconv.MessagingSystemKey.String("kafka"),
+				attribute.String("outcome", "success"),
+				attribute.String("topic", topicName),
+			),
 		))
 		logger.Info("created kafka topic", zap.String("topic", topicName))
 	}

--- a/pubsublite/internal/telemetry/consumer.go
+++ b/pubsublite/internal/telemetry/consumer.go
@@ -108,8 +108,8 @@ func Consumer(
 			}
 		}
 
-		metrics.fetched.Add(context.Background(), 1, metric.WithAttributes(
-			attrs...,
+		metrics.fetched.Add(context.Background(), 1, metric.WithAttributeSet(
+			attribute.NewSet(attrs...),
 		))
 
 		if msg.Attributes != nil {
@@ -130,9 +130,9 @@ func Consumer(
 		span.SetAttributes(
 			attribute.Float64(msgDelayKey, delay),
 		)
-		metrics.queuedDelay.Record(context.Background(), delay, metric.WithAttributes(
-			attrs...,
-		))
+		metrics.queuedDelay.Record(context.Background(), delay,
+			metric.WithAttributeSet(attribute.NewSet(attrs...)),
+		)
 
 		receive(ctx, msg)
 	}

--- a/pubsublite/internal/telemetry/publisher.go
+++ b/pubsublite/internal/telemetry/publisher.go
@@ -117,14 +117,14 @@ func (p *Producer) Publish(ctx context.Context, msg *pubsub.Message) pubsubabs.P
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			p.metrics.errored.Add(context.Background(), 1, metric.WithAttributes(
-				attrs...,
-			))
+			p.metrics.errored.Add(context.Background(), 1,
+				metric.WithAttributeSet(attribute.NewSet(attrs...)),
+			)
 		} else {
 			span.SetStatus(codes.Ok, "success")
-			p.metrics.produced.Add(context.Background(), 1, metric.WithAttributes(
-				attrs...,
-			))
+			p.metrics.produced.Add(context.Background(), 1,
+				metric.WithAttributeSet(attribute.NewSet(attrs...)),
+			)
 		}
 		span.End()
 	}()

--- a/pubsublite/manager.go
+++ b/pubsublite/manager.go
@@ -375,12 +375,12 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 
 			o.ObserveInt64(
 				consumerGroupLagMetric, lag,
-				metric.WithAttributes(commonAttributes...),
-				metric.WithAttributes(
+				metric.WithAttributeSet(attribute.NewSet(append(
+					commonAttributes,
 					attribute.String("topic", string(topic)),
 					attribute.String("group", consumer),
 					attribute.Int("partition", partition),
-				),
+				)...)),
 			)
 		}
 		return nil


### PR DESCRIPTION
Replace all `metric.WithAttributes` with `metric.WithAttributeSet`. This leads to less allocations and a notable performance gain due to reduced allocations (less copying).

```
$ benchstat main.txt attrset.txt
goos: darwin
goarch: arm64
pkg: github.com/elastic/apm-queue/v2/kafka
                                                                     │   main.txt   │             attrset.txt             │
                                                                     │    sec/op    │    sec/op     vs base               │
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_1_records-4       935.6n ±  8%   945.4n ±  5%        ~ (p=0.937 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_1_records-4      876.4n ±  2%   877.0n ±  1%        ~ (p=0.485 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_1_records-4     5.206µ ±  5%   4.755µ ±  9%   -8.67% (p=0.004 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_1_records-4    54.12µ ±  6%   46.89µ ±  9%  -13.36% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_10_records-4      5.956µ ±  5%   6.186µ ±  6%        ~ (p=0.394 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_10_records-4     5.467µ ±  6%   5.390µ ±  3%        ~ (p=0.180 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_10_records-4    53.89µ ±  2%   45.62µ ± 12%  -15.35% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_10_records-4   563.6µ ±  7%   464.3µ ±  6%  -17.61% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1000_topic_2_partition_10_records-4   8.242m ± 11%   7.339m ±  7%  -10.96% (p=0.009 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_50_records-4      29.58µ ±  2%   30.22µ ±  1%        ~ (p=0.065 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_50_records-4     27.66µ ± 16%   27.43µ ±  5%        ~ (p=0.818 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_50_records-4    265.5µ ±  4%   256.3µ ±  6%   -3.46% (p=0.026 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_50_records-4   3.185m ±  8%   2.211m ±  7%  -30.58% (p=0.002 n=6)
geomean                                                                42.09µ         38.79µ         -7.85%

                                                                     │   main.txt   │             attrset.txt              │
                                                                     │  consumed/s  │  consumed/s    vs base               │
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_1_records-4       837.1k ± 12%    876.9k ±  6%        ~ (p=0.065 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_1_records-4      968.6k ±  2%   1069.7k ±  3%  +10.44% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_1_records-4     518.1k ±  6%    559.2k ±  8%        ~ (p=0.065 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_1_records-4    325.2k ±  7%    323.9k ±  9%        ~ (p=0.937 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_10_records-4      755.7k ±  7%    783.3k ±  8%        ~ (p=0.818 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_10_records-4     828.6k ± 11%    886.2k ±  3%   +6.95% (p=0.004 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_10_records-4    490.2k ±  3%    568.2k ±  3%  +15.92% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_10_records-4   325.6k ± 11%    338.8k ±  6%        ~ (p=0.485 n=6)
Consumer/100MaxPoll/100_max_poll_1000_topic_2_partition_10_records-4   119.3k ±  8%    112.6k ± 16%        ~ (p=0.589 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_50_records-4      682.4k ±  5%    777.4k ±  3%  +13.92% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_50_records-4     757.1k ± 24%    800.5k ±  8%   +5.74% (p=0.041 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_50_records-4    519.8k ± 12%    551.7k ±  9%        ~ (p=0.180 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_50_records-4   298.7k ±  8%    375.0k ± 10%  +25.54% (p=0.002 n=6)
geomean                                                                502.6k          539.6k         +7.36%

                                                                     │   main.txt   │             attrset.txt             │
                                                                     │     B/op     │     B/op      vs base               │
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_1_records-4       2.724Ki ± 2%   2.385Ki ± 2%  -12.44% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_1_records-4      2.806Ki ± 0%   2.475Ki ± 1%  -11.78% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_1_records-4     17.30Ki ± 3%   13.99Ki ± 4%  -19.15% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_1_records-4    171.3Ki ± 4%   136.5Ki ± 5%  -20.34% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_10_records-4      18.05Ki ± 1%   14.98Ki ± 2%  -17.00% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_10_records-4     18.63Ki ± 2%   15.69Ki ± 3%  -15.77% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_10_records-4    168.3Ki ± 2%   134.1Ki ± 4%  -20.30% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_10_records-4   1.716Mi ± 2%   1.342Mi ± 3%  -21.81% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1000_topic_2_partition_10_records-4   24.74Mi ± 5%   20.68Mi ± 7%  -16.42% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_50_records-4      84.45Ki ± 1%   71.55Ki ± 1%  -15.27% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_50_records-4     90.72Ki ± 5%   74.30Ki ± 2%  -18.09% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_50_records-4    840.7Ki ± 1%   697.1Ki ± 5%  -17.08% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_50_records-4   8.674Mi ± 3%   6.748Mi ± 6%  -22.21% (p=0.002 n=6)
geomean                                                                130.7Ki        107.8Ki       -17.57%

                                                                     │  main.txt   │            attrset.txt             │
                                                                     │  allocs/op  │  allocs/op   vs base               │
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_1_records-4        28.50 ± 2%    27.00 ± 4%   -5.26% (p=0.009 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_1_records-4       29.00 ± 0%    28.00 ± 0%   -3.45% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_1_records-4      142.0 ± 1%    130.0 ± 3%   -8.45% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_1_records-4    1.347k ± 1%   1.167k ± 2%  -13.43% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_10_records-4       156.0 ± 1%    145.0 ± 1%   -7.05% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_10_records-4      156.0 ± 1%    144.0 ± 1%   -7.69% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_10_records-4    1.329k ± 1%   1.192k ± 2%  -10.27% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_10_records-4   13.59k ± 2%   11.63k ± 1%  -14.39% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1000_topic_2_partition_10_records-4   188.5k ± 3%   169.8k ± 4%   -9.94% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_1_partition_50_records-4       709.5 ± 1%    677.0 ± 1%   -4.58% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_1_topic_10_partition_50_records-4      724.0 ± 4%    663.5 ± 1%   -8.36% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_10_topic_10_partition_50_records-4    6.673k ± 3%   6.074k ± 2%   -8.96% (p=0.002 n=6)
Consumer/100MaxPoll/100_max_poll_100_topic_10_partition_50_records-4   69.25k ± 2%   58.26k ± 2%  -15.86% (p=0.002 n=6)
geomean                                                                1.091k         991.6        -9.13%
```