### PR TITLE
kafka: Reduce consumer/producer allocations

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -254,7 +254,7 @@ func TestCommonConfigFileHook(t *testing.T) {
 	require.NoError(t, cfg.finalize())
 	assert.Equal(t, []string{"testing.invalid"}, cfg.Brokers)
 
-	client, err := cfg.newClient()
+	client, err := cfg.newClient(nil)
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -212,7 +212,7 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 	if cfg.ShutdownGracePeriod <= 0 {
 		cfg.ShutdownGracePeriod = 5 * time.Second
 	}
-	client, err := cfg.newClient(opts...)
+	client, err := cfg.newClient(cfg.TopicAttributeFunc, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed creating kafka consumer: %w", err)
 	}

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -68,7 +68,7 @@ func NewManager(cfg ManagerConfig) (*Manager, error) {
 	if err := cfg.finalize(); err != nil {
 		return nil, fmt.Errorf("kafka: invalid manager config: %w", err)
 	}
-	client, err := cfg.newClient()
+	client, err := cfg.newClient(nil)
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed creating kafka client: %w", err)
 	}

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -151,7 +151,7 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	if cfg.ManualFlushing {
 		opts = append(opts, kgo.ManualFlushing())
 	}
-	client, err := cfg.newClient(opts...)
+	client, err := cfg.newClient(cfg.TopicAttributeFunc, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("kafka: failed creating producer: %w", err)
 	}


### PR DESCRIPTION
Uses more efficient kgo.Hook which reduces the allocations required per event. The result is a drop of ~40% in allocations.

```
benchstat main.txt batch_metrics.txt                                                                                                                                                                             <region:us-east-1>
goos: darwin
goarch: arm64
pkg: github.com/elastic/apm-queue/v2/kafka
                    │  main.txt   │          batch_metrics.txt         │
                    │   sec/op    │    sec/op     vs base              │
Consumer/500MaxPoll   667.5µ ± 7%   444.5µ ± 22%  -33.41% (p=0.002 n=6)

                    │   main.txt   │       batch_metrics.txt       │
                    │  consumed/s  │  consumed/s   vs base         │
Consumer/500MaxPoll   385.7k ± 18%   396.3k ± 11%  ~ (p=0.937 n=6)

                    │   main.txt    │          batch_metrics.txt       │
                    │     B/op      │     B/op       vs base           │
Consumer/500MaxPoll   1288.9Ki ± 6%   687.2Ki ± 13%  -46.68% (p=0.002 n=6)

                    │   main.txt   │         batch_metrics.txt         │
                    │  allocs/op   │  allocs/op   vs base              │
Consumer/500MaxPoll   10.898k ± 5%   6.546k ± 5%  -39.93% (p=0.002 n=6)
```