### PR TITLE
feat: use oidc for auth with GCP

### DIFF
--- a/.github/actions/system-test/action.yml
+++ b/.github/actions/system-test/action.yml
@@ -3,15 +3,9 @@ name: system-test
 description: Steps to run system test
 
 inputs:
-  vault-url:
-    description: 'Vault URL'
+  workload-identity-provider:
+    description: 'GCP Workload Identity Provider'
     required: true
-  vault-role-id:
-      description: 'Vault Role ID'
-      required: true
-  vault-secret-id:
-      description: 'Vault Secret ID'
-      required: true
 
 runs:
   using: composite
@@ -19,18 +13,11 @@ runs:
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.4.6
-    - uses: hashicorp/vault-action@v2.7.4
-      with:
-        url: ${{ inputs.vault-url }}
-        roleId: ${{ inputs.vault-role-id }}
-        secretId: ${{ inputs.vault-secret-id }}
-        method: approle
-        secrets: |
-          secret/observability-team/ci/service-account/apm-queue-system-tests credentials | GOOGLE_CREDS ;
     - id: gcp-auth
       uses: 'google-github-actions/auth@v2'
       with:
-        credentials_json: '${{ env.GOOGLE_CREDS }}'
+        project_id: 'elastic-observability'
+        workload_identity_provider: '${{ inputs.workload-identity-provider }}'
     - uses: 'google-github-actions/setup-gcloud@v2'
     - uses: 'google-github-actions/get-gke-credentials@v2'
       with:

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   run-system-tests:
@@ -21,6 +22,4 @@ jobs:
           && github.actor != 'dependabot[bot]'
         uses: ./.github/actions/system-test
         with:
-          vault-url: ${{ secrets.VAULT_ADDR }}
-          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
-          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          workload-identity-provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'


### PR DESCRIPTION
## What is the change being made?

* Use OIDC to auth with Google services.

## Why is the change being made?

* Avoid the use of Vault and rely on keyless auth for CI.