### PR TITLE
github-action: update condition

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - test-github
 
 permissions:
   contents: read
@@ -18,8 +19,8 @@ jobs:
       # This step is skipped if the pull request is from a forked repository or dependabot
       # In that case the job just creates a green status check on the pull request.
       - if: |
-          github.event.pull_request.head.repo.full_name == github.repository
-          && github.actor != 'dependabot[bot]'
+          ${{ ( github.event_name == 'push' && ( github.ref == 'main' || github.ref == 'test-github' ) ) ||
+              ( github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository ) }}
         uses: ./.github/actions/system-test
         with:
           workload-identity-provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'


### PR DESCRIPTION
### What

Support for push to main in addition to PRs that are not created by dependabot in the upstream.

### Why

https://github.com/elastic/apm-queue/pull/372 did solve the dependabot issue but it added a regression with the `main` branch and system tests were not triggered:

<img width="1214" alt="image" src="https://github.com/elastic/apm-queue/assets/2871786/779bd809-ce60-4c40-94f9-2e2d0070bbae">

