### PR TITLE
feat: enable dependabot for system tests

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -19,7 +19,6 @@ jobs:
       # In that case the job just creates a green status check on the pull request.
       - if: |
           github.event.pull_request.head.repo.full_name == github.repository
-          && github.actor != 'dependabot[bot]'
         uses: ./.github/actions/system-test
         with:
           workload-identity-provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'


### PR DESCRIPTION
## What is the change being made?

* Enable dependabot for system tests.

## Why is the change being made?

* It was disabled previously due to vault access.
* Since we are using OIDC, we can re-enable it.