### PR TITLE
github-action: support push events

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -18,7 +18,10 @@ jobs:
       # This step is skipped if the pull request is from a forked repository or dependabot
       # In that case the job just creates a green status check on the pull request.
       - if: |
-          github.event.pull_request.head.repo.full_name == github.repository
+          ( github.event_name != 'pull_request'
+            ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
         uses: ./.github/actions/system-test
         with:
           workload-identity-provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # This step is skipped if the pull request is from a forked repository or dependabot
+      # This step is skipped if the pull request is from a forked repository
       # In that case the job just creates a green status check on the pull request.
       - if: |
           ( github.event_name != 'pull_request'


### PR DESCRIPTION
### What

Enable system-tests for push events in addition to Pull Requests in feature branches


### Why

I didn't see any executions for the system-tests on merge commits onto `main` in:
- https://github.com/elastic/apm-queue/actions/workflows/system-test.yml

<img width="1296" alt="image" src="https://github.com/elastic/apm-queue/assets/2871786/6ceea85b-ad45-4e94-8184-751affd67de3">

But only for dependabot.