### PR TITLE
feat: partition id as record metadata

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -522,6 +522,10 @@ func newPartitionConsumer(ctx context.Context,
 	return &c
 }
 
+// This key is part of metadata as a mean to convey information
+// about the partition IDs that are assigned to each apmqueue.Processor.
+const metadataCtxPartitionKey = "partition_id"
+
 // consumeTopicPartition processes the records for a topic and partition. The
 // records will be processed asynchronously.
 func (c *pc) consumeRecords(ftp kgo.FetchTopicPartition) {
@@ -530,10 +534,14 @@ func (c *pc) consumeRecords(ftp kgo.FetchTopicPartition) {
 		// only the first record is received.
 		last := -1
 		for i, msg := range ftp.Records {
-			meta := make(map[string]string)
+			meta := make(map[string]string, len(msg.Headers))
 			for _, h := range msg.Headers {
 				meta[h.Key] = string(h.Value)
 			}
+			// Add the partition ID to the metadata to allow the processor to
+			// parallelize the processing of records from different partitions.
+			meta[metadataCtxPartitionKey] = fmt.Sprint(ftp.Partition)
+
 			processCtx := queuecontext.WithMetadata(msg.Context, meta)
 			record := apmqueue.Record{
 				Topic:       c.topic,

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -522,10 +522,6 @@ func newPartitionConsumer(ctx context.Context,
 	return &c
 }
 
-// This key is part of metadata as a mean to convey information
-// about the partition IDs that are assigned to each apmqueue.Processor.
-const metadataCtxPartitionKey = "partition_id"
-
 // consumeTopicPartition processes the records for a topic and partition. The
 // records will be processed asynchronously.
 func (c *pc) consumeRecords(ftp kgo.FetchTopicPartition) {
@@ -538,13 +534,11 @@ func (c *pc) consumeRecords(ftp kgo.FetchTopicPartition) {
 			for _, h := range msg.Headers {
 				meta[h.Key] = string(h.Value)
 			}
-			// Add the partition ID to the metadata to allow the processor to
-			// parallelize the processing of records from different partitions.
-			meta[metadataCtxPartitionKey] = fmt.Sprint(ftp.Partition)
 
 			processCtx := queuecontext.WithMetadata(msg.Context, meta)
 			record := apmqueue.Record{
 				Topic:       c.topic,
+				Partition:   msg.Partition,
 				OrderingKey: msg.Key,
 				Value:       msg.Value,
 			}

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -481,8 +481,9 @@ func TestConsumerContextPropagation(t *testing.T) {
 	}
 	processed := make(chan struct{})
 	expectedMeta := map[string]string{
-		"key":       "value",
-		"timestamp": time.Now().Format(time.RFC3339),
+		"key":          "value",
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"partition_id": "0",
 	}
 	consumer := newConsumer(t, ConsumerConfig{
 		CommonConfig: commonCfg,

--- a/pubsublite/consumer_test.go
+++ b/pubsublite/consumer_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/pubsublite/apiv1/pubsublitepb"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -137,39 +138,41 @@ func TestConsumerConsume(t *testing.T) {
 		records[sp] = append(records[sp], record)
 	}
 
-	assert.Equal(t, map[subscriptionPartition][]apmqueue.Record{
+	expected := map[subscriptionPartition][]apmqueue.Record{
 		subscriptionPartition{
 			Subscription: topic1SubscriptionPath,
 			Partition:    1,
-		}: []apmqueue.Record{
-			{Topic: "topic1", Value: []byte("message1")},
-			{Topic: "topic1", Value: []byte("message2")},
+		}: {
+			{Topic: "topic1", Value: []byte("message1"), Partition: 1},
+			{Topic: "topic1", Value: []byte("message2"), Partition: 1},
 		},
 
 		subscriptionPartition{
 			Subscription: topic1SubscriptionPath,
 			Partition:    2,
-		}: []apmqueue.Record{
-			{Topic: "topic1", Value: []byte("message1")},
-			{Topic: "topic1", Value: []byte("message2")},
+		}: {
+			{Topic: "topic1", Value: []byte("message1"), Partition: 2},
+			{Topic: "topic1", Value: []byte("message2"), Partition: 2},
 		},
 
 		subscriptionPartition{
 			Subscription: topic2SubscriptionPath,
 			Partition:    1,
-		}: []apmqueue.Record{
-			{Topic: "topic2", Value: []byte("message1")},
-			{Topic: "topic2", Value: []byte("message2")},
+		}: {
+			{Topic: "topic2", Value: []byte("message1"), Partition: 1},
+			{Topic: "topic2", Value: []byte("message2"), Partition: 1},
 		},
 
 		subscriptionPartition{
 			Subscription: topic2SubscriptionPath,
 			Partition:    2,
-		}: []apmqueue.Record{
-			{Topic: "topic2", Value: []byte("message1")},
-			{Topic: "topic2", Value: []byte("message2")},
+		}: {
+			{Topic: "topic2", Value: []byte("message1"), Partition: 2},
+			{Topic: "topic2", Value: []byte("message2"), Partition: 2},
 		},
-	}, records)
+	}
+	assert.EqualValues(t, expected, records, "records mismatch\n%v",
+		cmp.Diff(expected, records))
 }
 
 func newConsumerService(t testing.TB) (*subscriberServiceServer, ConsumerConfig) {

--- a/queue.go
+++ b/queue.go
@@ -75,13 +75,17 @@ type Producer interface {
 
 // Record wraps a record's value with the topic where it's produced / consumed.
 type Record struct {
-	// Topics holds the topic where the record will be produced.
-	Topic Topic
 	// OrderingKey is an optional field that is hashed to map to a partition.
 	// Records with same ordering key are routed to the same partition.
 	OrderingKey []byte
 	// Value holds the record's content. It must not be mutated after Produce.
 	Value []byte
+	// Topics holds the topic where the record will be produced.
+	Topic Topic
+	// Partition identifies the partition ID where the record was polled from.
+	// It is optional and only used for consumers.
+	// When not specified, the zero value for int32 (0) identifies the only partition.
+	Partition int32
 }
 
 // Processor defines record processing signature.

--- a/queuecontext/context.go
+++ b/queuecontext/context.go
@@ -57,3 +57,13 @@ type detachedContext struct {
 func (c *detachedContext) Value(key interface{}) interface{} {
 	return c.orig.Value(key)
 }
+
+func Enrich(ctx context.Context, key string, value string) context.Context {
+	meta, ok := MetadataFromContext(ctx)
+	if !ok {
+		meta = make(map[string]string)
+	}
+
+	meta[key] = value
+	return WithMetadata(ctx, meta)
+}

--- a/queuecontext/context_test.go
+++ b/queuecontext/context_test.go
@@ -57,5 +57,5 @@ func TestEnrichedContext(t *testing.T) {
 
 	meta, ok := MetadataFromContext(ctx)
 	require.True(t, ok)
-	assert.Equal(t, map[string]string{"a": "b", "partition": "1"}, meta)
+	assert.Equal(t, map[string]string{"a": "b", "partition_id": "1"}, meta)
 }

--- a/queuecontext/context_test.go
+++ b/queuecontext/context_test.go
@@ -49,3 +49,13 @@ func TestDetachedContext(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, map[string]string{"a": "b"}, meta)
 }
+
+func TestEnrichedContext(t *testing.T) {
+	ctx := context.Background()
+	ctx = WithMetadata(ctx, map[string]string{"a": "b"})
+	ctx = Enrich(ctx, "partition_id", "1")
+
+	meta, ok := MetadataFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, map[string]string{"a": "b", "partition": "1"}, meta)
+}


### PR DESCRIPTION
### Reason for this PR

We want to allow consumers to understand how many partitions they are poling from.
The partition Id is avaiable in both kafka and pubsublite so we should expose it and let consumers use it at their own advantage.

### Details

~We create a new un-exported string constant, with value `partition_id`. This will be populated in the context.Context attached to each kgo.Record via the `queuecontext` package.~
EDIT: accepted proposal to add the partition as a field of the `Record` struct.

Consumers will be ale to understand which partition a record was polled from by parsing the record field.

Unrelated small performance improvement: pre-allocate map capacity to the length of headers.