### PR TITLE
Align connects metrics

### DIFF
--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -157,6 +157,7 @@ func TestManagerDeleteTopics(t *testing.T) {
 		{Name: "messaging.kafka.connects.count", Unit: "1"}: {
 			{K: "messaging.system", V: "kafka"}: 2,
 			{K: "namespace", V: "name_space"}:   2,
+			{K: "outcome", V: "success"}:        2,
 		},
 		{Name: "messaging.kafka.read_bytes.count", Unit: "By"}: {
 			{K: "messaging.system", V: "kafka"}: 725,

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -73,7 +73,6 @@ type metricHooks struct {
 	// kotel metrics
 
 	connects    metric.Int64Counter
-	connectErrs metric.Int64Counter
 	disconnects metric.Int64Counter
 
 	writeErrs  metric.Int64Counter
@@ -115,15 +114,6 @@ func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connects instrument, %w", err)
-	}
-
-	connectErrs, err := m.Int64Counter(
-		"messaging.kafka.connect_errors.count",
-		metric.WithUnit(unitCount),
-		metric.WithDescription("Total number of connection errors, by broker"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create connectErrs instrument, %w", err)
 	}
 
 	disconnects, err := m.Int64Counter(
@@ -287,7 +277,6 @@ func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string,
 		topicPrefix: topicPrefix,
 		// kotel metrics
 		connects:    connects,
-		connectErrs: connectErrs,
 		disconnects: disconnects,
 
 		writeErrs:  writeErrs,

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -323,19 +323,21 @@ func formatMetricError(name string, err error) error {
 }
 
 func (h *metricHooks) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
-	attrs := make([]attribute.KeyValue, 0, 2)
+	attrs := make([]attribute.KeyValue, 0, 3)
 	attrs = append(attrs, semconv.MessagingSystem("kafka"))
 	if h.namespace != "" {
 		attrs = append(attrs, attribute.String("namespace", h.namespace))
 	}
 	if err != nil {
-		h.connectErrs.Add(
+		attrs = append(attrs, attribute.String("outcome", "failure"))
+		h.connects.Add(
 			context.Background(),
 			1,
 			metric.WithAttributeSet(attribute.NewSet(attrs...)),
 		)
 		return
 	}
+	attrs = append(attrs, attribute.String("outcome", "success"))
 	h.connects.Add(
 		context.Background(),
 		1,

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -329,6 +329,11 @@ func (h *metricHooks) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, 
 		attrs = append(attrs, attribute.String("namespace", h.namespace))
 	}
 	if err != nil {
+		h.connectErrs.Add(
+			context.Background(),
+			1,
+			metric.WithAttributeSet(attribute.NewSet(attrs...)),
+		)
 		attrs = append(attrs, attribute.String("outcome", "failure"))
 		h.connects.Add(
 			context.Background(),

--- a/kafka/metrics.go
+++ b/kafka/metrics.go
@@ -73,6 +73,7 @@ type metricHooks struct {
 	// kotel metrics
 
 	connects    metric.Int64Counter
+	connectErrs metric.Int64Counter
 	disconnects metric.Int64Counter
 
 	writeErrs  metric.Int64Counter
@@ -114,6 +115,15 @@ func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connects instrument, %w", err)
+	}
+
+	connectErrs, err := m.Int64Counter(
+		"messaging.kafka.connect_errors.count",
+		metric.WithUnit(unitCount),
+		metric.WithDescription("Total number of connection errors, by broker"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connectErrs instrument, %w", err)
 	}
 
 	disconnects, err := m.Int64Counter(
@@ -277,6 +287,7 @@ func newKgoHooks(mp metric.MeterProvider, namespace, topicPrefix string,
 		topicPrefix: topicPrefix,
 		// kotel metrics
 		connects:    connects,
+		connectErrs: connectErrs,
 		disconnects: disconnects,
 
 		writeErrs:  writeErrs,

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -172,6 +172,7 @@ func TestProducerMetrics(t *testing.T) {
 		require.NoError(t, producer.Close())
 		test(context.Background(), t, producer, rdr, []metricdata.Metrics{want},
 			"messaging.kafka.connect_errors.count",
+			"messaging.kafka.connects.count",
 		)
 	})
 	t.Run("Produced", func(t *testing.T) {

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -104,6 +104,7 @@ func TestProducerMetrics(t *testing.T) {
 		test(ctx, t, producer, rdr, want,
 			"messaging.kafka.connects.count",
 			"messaging.kafka.disconnects.count",
+			"messaging.kafka.connect_errors.count",
 			"messaging.kafka.write_errors.count",
 		)
 	})
@@ -136,6 +137,7 @@ func TestProducerMetrics(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		test(ctx, t, producer, rdr, want,
+			"messaging.kafka.connect_errors.count",
 			"messaging.kafka.connects.count",
 			"messaging.kafka.disconnects.count",
 			"messaging.kafka.write_bytes",
@@ -169,7 +171,7 @@ func TestProducerMetrics(t *testing.T) {
 		}
 		require.NoError(t, producer.Close())
 		test(context.Background(), t, producer, rdr, []metricdata.Metrics{want},
-			"messaging.kafka.connects.count",
+			"messaging.kafka.connect_errors.count",
 		)
 	})
 	t.Run("Produced", func(t *testing.T) {

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -104,7 +104,6 @@ func TestProducerMetrics(t *testing.T) {
 		test(ctx, t, producer, rdr, want,
 			"messaging.kafka.connects.count",
 			"messaging.kafka.disconnects.count",
-			"messaging.kafka.connect_errors.count",
 			"messaging.kafka.write_errors.count",
 		)
 	})
@@ -137,7 +136,6 @@ func TestProducerMetrics(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		test(ctx, t, producer, rdr, want,
-			"messaging.kafka.connect_errors.count",
 			"messaging.kafka.connects.count",
 			"messaging.kafka.disconnects.count",
 			"messaging.kafka.write_bytes",
@@ -171,7 +169,7 @@ func TestProducerMetrics(t *testing.T) {
 		}
 		require.NoError(t, producer.Close())
 		test(context.Background(), t, producer, rdr, []metricdata.Metrics{want},
-			"messaging.kafka.connect_errors.count",
+			"messaging.kafka.connects.count",
 		)
 	})
 	t.Run("Produced", func(t *testing.T) {


### PR DESCRIPTION
This PR address https://github.com/twmb/franz-go/issues/670 but in the monitoring implementation introduced in this module by #460.

It changes Kafka connection metrics, instead of relying on 2 different metrics to report Kafka connections successes and failures, use only a single metric with distinct `outcome` attribute based on the outcome. This implementation does not guard this new behaviour under a flag, like I did for the contribution to `franz-go` as I don't think it's useful is a specialized implementation like we have here. But still this introduces a breaking change in the `kafka` package monitoring so I'm open to revisit this decision if we want to keep backwards compatibility.

Metric `messaging.kafka.connect_errors.count` has been removed.

Attribute `outcome` has been added to `messaging.kafka.connects.count` with 2 possible values: `success` and `failure`.


