### PR TITLE
kafka: less verbose producer tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO_TEST_TIMEOUT=60s
+GO_VERBOSE=
 
 .DEFAULT_GOAL := all
 all: test
@@ -19,7 +20,11 @@ clean:
 
 .PHONY: test
 test: go.mod
-	go test -race -v -timeout=$(GO_TEST_TIMEOUT) ./...
+	go test -race $(GO_VERBOSE) -timeout=$(GO_TEST_TIMEOUT) ./...
+
+.PHONY: test-verbose
+test-verbose:
+	make test GO_VERBOSE=-v
 
 MODULE_DEPS=$(sort $(shell go list -deps -tags=darwin,linux,windows -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}"))
 

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -222,7 +222,16 @@ func TestNewProducerBasic(t *testing.T) {
 	test(t, false)
 }
 
+func testVerboseLogger(t *testing.T) *zap.Logger {
+	t.Helper()
+	if testing.Verbose() {
+		return zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel))
+	}
+	return zap.NewNop()
+}
+
 func TestProducerGracefulShutdown(t *testing.T) {
+	l := testVerboseLogger(t)
 	test := func(t testing.TB, dt apmqueue.DeliveryType, syncProducer bool) {
 		brokers := newClusterAddrWithTopics(t, 1, "topic")
 		var processed atomic.Int64
@@ -230,14 +239,14 @@ func TestProducerGracefulShutdown(t *testing.T) {
 		producer := newProducer(t, ProducerConfig{
 			CommonConfig: CommonConfig{
 				Brokers: brokers,
-				Logger:  zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel)),
+				Logger:  l,
 			},
 			Sync: syncProducer,
 		})
 		consumer := newConsumer(t, ConsumerConfig{
 			CommonConfig: CommonConfig{
 				Brokers: brokers,
-				Logger:  zaptest.NewLogger(t, zaptest.Level(zapcore.DebugLevel)),
+				Logger:  l,
 			},
 			GroupID:  "group",
 			Topics:   []apmqueue.Topic{"topic"},


### PR DESCRIPTION
Current producer tests set up a zap debug logger that is quite verbose. Going through this big output when trying to identify a specific test failure (which may be unrelated to the verbose tests) is quite painful.

To address this in this PR the debug logger is only initialized when `-v` is specified. This allows the choice to developers to run with or without the verbose logger enabled.
It also updates `make test` to run go test in non verbose mode and adds an additional make target, `test-verbose` to run with `-v`.

This change is reflected in CI where the less verbose target is used, but I don't have strong opinions there. I see the debug logger as a development/bugfixing aid more than useful information to have on CI and there is the dedicated `test-verbose` make target for such scenarios.

We get from this:

to this:

```
```
