### PR TITLE
kafka: Add a few new config options

### DIFF
--- a/kafka/common.go
+++ b/kafka/common.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -149,6 +150,11 @@ type CommonConfig struct {
 	// - producer.messages.count
 	// - consumer.messages.fetched
 	TopicAttributeFunc TopicAttributeFunc
+
+	// MetadataMaxAge is the maximum age of metadata before it is refreshed.
+	// The lower the value the more frequently new topics will be discovered.
+	// If zero, the default value of 5 minutes is used.
+	MetadataMaxAge time.Duration
 
 	hooks []kgo.Hook
 }
@@ -284,6 +290,9 @@ func (cfg *CommonConfig) newClient(topicAttributeFunc TopicAttributeFunc, additi
 		opts = append(opts,
 			kgo.WithHooks(metricHooks),
 		)
+	}
+	if cfg.MetadataMaxAge > 0 {
+		opts = append(opts, kgo.MetadataMaxAge(cfg.MetadataMaxAge))
 	}
 	if len(cfg.hooks) != 0 {
 		opts = append(opts, kgo.WithHooks(cfg.hooks...))

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -113,6 +113,11 @@ type ConsumerConfig struct {
 	// Kafka consumer setting: fetch.min.bytes
 	// Docs: https://kafka.apache.org/28/documentation.html#consumerconfigs_fetch.min.bytes
 	FetchMinBytes int32
+
+	// ConsumePreferringLagFn alters the order in which partitions are consumed.
+	// Use with caution, as this can lead to uneven consumption of partitions,
+	// and in the worst case scenario, in partitions starved out from being consumed.
+	PreferLagFn kgo.PreferLagFn
 }
 
 // finalize ensures the configuration is valid, setting default values from
@@ -217,6 +222,9 @@ func NewConsumer(cfg ConsumerConfig) (*Consumer, error) {
 	}
 	if cfg.MaxConcurrentFetches > 0 {
 		opts = append(opts, kgo.MaxConcurrentFetches(cfg.MaxConcurrentFetches))
+	}
+	if cfg.PreferLagFn != nil {
+		opts = append(opts, kgo.ConsumePreferringLagFn(cfg.PreferLagFn))
 	}
 	if cfg.ShutdownGracePeriod <= 0 {
 		cfg.ShutdownGracePeriod = 5 * time.Second

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -88,6 +88,10 @@ type ProducerConfig struct {
 	// BatchListener is called per topic/partition after a batch is
 	// successfully produced to a Kafka broker.
 	BatchListener BatchWriteListener
+
+	// RecordPartitioner is a function that returns the partition to which
+	// a record should be sent. If nil, the default partitioner is used.
+	RecordPartitioner kgo.Partitioner
 }
 
 // BatchWriteListener specifies a callback function that is invoked after a batch is
@@ -173,6 +177,9 @@ func NewProducer(cfg ProducerConfig) (*Producer, error) {
 	}
 	if cfg.BatchListener != nil {
 		opts = append(opts, kgo.WithHooks(cfg.BatchListener))
+	}
+	if cfg.RecordPartitioner != nil {
+		opts = append(opts, kgo.RecordPartitioner(cfg.RecordPartitioner))
 	}
 	client, err := cfg.newClient(cfg.TopicAttributeFunc, opts...)
 	if err != nil {


### PR DESCRIPTION
This commit adds a few new configuration options to the kafka package.

* `MetadataMaxAge`: The maximum age of metadata before it is refreshed. The lower the value, the quicker the Kafka client will pick up topic changes.
* `ConsumePreferringLagFn`: A function that alters the order in which partitions are consumed by the consumer. Use with caution, as this can lead to uneven consumption of partitions.
* `RecordPartitioner`: A function that returns the partition to which a record should be sent.