### PR TITLE
kafka: improve consumer test stability

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -26,10 +26,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kfake"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"go.uber.org/zap"
 )
@@ -274,4 +276,27 @@ func TestCommonConfigFileHook(t *testing.T) {
 	// and bootstrap.servers to be reevaluated.
 	err = client.Ping(context.Background())
 	require.NoError(t, err)
+}
+
+func newClusterAddrWithTopics(t testing.TB, partitions int32, topics ...string) []string {
+	t.Helper()
+	cluster, err := kfake.NewCluster(kfake.SeedTopics(partitions, topics...))
+	require.NoError(t, err)
+	t.Cleanup(cluster.Close)
+
+	return cluster.ListenAddrs()
+}
+
+func newClusterWithTopics(t testing.TB, partitions int32, topics ...string) (*kgo.Client, []string) {
+	t.Helper()
+	addrs := newClusterAddrWithTopics(t, partitions, topics...)
+
+	client, err := kgo.NewClient(
+		kgo.SeedBrokers(addrs...),
+		// Reduce the max wait time to speed up tests.
+		kgo.FetchMaxWait(100*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	return client, addrs
 }

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/twmb/franz-go/pkg/kfake"
 	"github.com/twmb/franz-go/pkg/kgo"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -312,26 +311,8 @@ func TestProducerConcurrentClose(t *testing.T) {
 	wg.Wait()
 }
 
-func newClusterAddrWithTopics(t testing.TB, partitions int32, topics ...string) []string {
-	t.Helper()
-	cluster, err := kfake.NewCluster(kfake.SeedTopics(partitions, topics...))
-	require.NoError(t, err)
-	t.Cleanup(cluster.Close)
-
-	return cluster.ListenAddrs()
-}
-
-func newClusterWithTopics(t testing.TB, partitions int32, topics ...string) (*kgo.Client, []string) {
-	t.Helper()
-	addrs := newClusterAddrWithTopics(t, partitions, topics...)
-
-	client, err := kgo.NewClient(kgo.SeedBrokers(addrs...))
-	require.NoError(t, err)
-
-	return client, addrs
-}
-
 func newProducer(t testing.TB, cfg ProducerConfig) *Producer {
+	t.Helper()
 	producer, err := NewProducer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
This commit improves the stability of the consumer test by reducing the `FetchMaxWait` to 100ms.