### PR TITLE
Improve unit test stability by running `10` times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GO_TEST_TIMEOUT=60s
+GO_TEST_COUNT=10
 
 .DEFAULT_GOAL := all
 all: test
@@ -19,7 +20,7 @@ clean:
 
 .PHONY: test
 test: go.mod
-	go test -race -v -timeout=$(GO_TEST_TIMEOUT) ./...
+	go test -race -v -count=$(GO_TEST_COUNT) -timeout=$(GO_TEST_TIMEOUT) ./...
 
 MODULE_DEPS=$(sort $(shell go list -deps -tags=darwin,linux,windows -f "{{with .Module}}{{if not .Main}}{{.Path}}{{end}}{{end}}"))
 


### PR DESCRIPTION
Updates the `test` Makefile target to run the unit tests 10 times. This makes it harder to commit flaky tests by forcing multiple executions in the CI pipeline.

We could increase the number of times the tests are run, but 10 seems like a reasonable trade-off between stability and execution time.