### PR TITLE
Fix flaky pubsublite test

### DIFF
--- a/pubsublite/internal/pubsubabs/publisher.go
+++ b/pubsublite/internal/pubsubabs/publisher.go
@@ -21,6 +21,7 @@ package pubsubabs
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 )
@@ -129,4 +130,6 @@ func SetPublishResult(r *IPublishResult, sid string, err error) {
 	r.serverID = sid
 	r.err = err
 	close(r.ready)
+	// Wait for fire-and-forget goroutine in producer.Publish
+	<-time.After(5 * time.Millisecond)
 }

--- a/pubsublite/internal/telemetry/publisher_test.go
+++ b/pubsublite/internal/telemetry/publisher_test.go
@@ -238,9 +238,6 @@ func TestPublisher(t *testing.T) {
 				pubsubabs.SetPublishResult(res, "msg-id", errors.New("failed processing message"))
 			}
 
-			// Wait for the async goroutine to finish runnning
-			time.Sleep(time.Millisecond)
-
 			spans := exp.GetSpans()
 			for i := range spans {
 				// Nullify data we don't use/can't set manually


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-queue/issues/562

This is not a proper fix, but I think it's a hacky improvement.

The problem with the hack in the unit test in https://github.com/elastic/apm-queue/blob/6675642e184c322eadac10a3c6155ed267fc8bdb/pubsublite/internal/telemetry/publisher_test.go#L242 is that the "logic" is tied to the unit test, not in the actual implementation. 

Though, this PR does not fully fix the issue, I believe that this PR is a more idiomatic implementation, until we can find a proper solution.

At the core the issue with the goroutine in https://github.com/elastic/apm-queue/blob/6675642e184c322eadac10a3c6155ed267fc8bdb/pubsublite/internal/telemetry/publisher.go#L114 is that we fire-and-forget about it.

The proper solution is to either:

1. Use wait-group, which to my understanding defeats the purpose of a fire-and-forget strategy
2. Orchestrate communication between the child and parent, which means we have to update the function interface, by either passing or returning a channel.