### PR TITLE
Fix flaky test in metric producer

### DIFF
--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -557,6 +557,9 @@ func setupTestProducer(t testing.TB, tafunc TopicAttributeFunc) (*Producer, sdkm
 			MeterProvider:      mp,
 			TopicAttributeFunc: tafunc,
 		},
+		ProduceCallback: func(*kgo.Record, error) {
+			time.Sleep(1 * time.Millisecond)
+		},
 		Sync: true,
 	})
 	return producer, rdr

--- a/kafka/metrics_test.go
+++ b/kafka/metrics_test.go
@@ -54,6 +54,10 @@ func TestProducerMetrics(t *testing.T) {
 			apmqueue.Record{Topic: topic, Value: []byte("2")},
 			apmqueue.Record{Topic: topic, Value: []byte("3")},
 		)
+
+		// Fixes https://github.com/elastic/apm-queue/issues/464
+		<-time.After(1 * time.Millisecond)
+
 		// Close the producer so records are flushed.
 		require.NoError(t, producer.Close())
 
@@ -556,9 +560,6 @@ func setupTestProducer(t testing.TB, tafunc TopicAttributeFunc) (*Producer, sdkm
 			TracerProvider:     noop.NewTracerProvider(),
 			MeterProvider:      mp,
 			TopicAttributeFunc: tafunc,
-		},
-		ProduceCallback: func(*kgo.Record, error) {
-			time.Sleep(1 * time.Millisecond)
 		},
 		Sync: true,
 	})


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-queue/issues/464

Adding a small delay after each record acknowledge seems to fix the flakiness of the `TestProducerMetrics/Producer` test.

The test only fails when running with `-race` locally:

```
go test -v -race -failfast ./kafka/
```

I am unable to properly deduce why this race is happening. From the solution it seems that the collector starts pulling metrics from the queue before a record has been ack. This makes no sense, since an ACK for ALL records are acknowledged before collection starts:

- `producer.Produce` successfully waits for all records to be ack on the queue
- `producer.Close` is actually blocking due to the `Flush` method being called: https://github.com/twmb/franz-go/blob/b77dd13e2bfaee7f5181df27b40ee4a4f6a73b09/pkg/kgo/producer.go#L1054
- Tying the context between `Produce` and `Close` doesn't work either.
- Removing the test cleanup  doesn't work: https://github.com/elastic/apm-queue/blob/24047fa333bb8ce173a51614bc632cfa3ccd1aa6/kafka/metrics_test.go#L549
- All the metric types are synchronous as explained in: https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument

What is more confusing is that only the following metrics experience a race in the `TestProducerMetrics/Producer` test: 
1. https://github.com/elastic/apm-queue/blob/24047fa333bb8ce173a51614bc632cfa3ccd1aa6/kafka/metrics_test.go#L195C19-L195C42
2. https://github.com/elastic/apm-queue/blob/24047fa333bb8ce173a51614bc632cfa3ccd1aa6/kafka/metrics_test.go#L219
3. https://github.com/elastic/apm-queue/blob/24047fa333bb8ce173a51614bc632cfa3ccd1aa6/kafka/metrics_test.go#L243

Where as https://github.com/elastic/apm-queue/blob/24047fa333bb8ce173a51614bc632cfa3ccd1aa6/kafka/metrics_test.go#L267 is always properly collected.


