### PR TITLE
fix: do not reuse logger in topiccreator

### DIFF
--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -165,9 +165,9 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 	}
 
 	var updateErrors []error
-	logger := c.m.cfg.Logger.With(loggerFields...)
 	for _, response := range responses.Sorted() {
 		topicName := strings.TrimPrefix(response.Topic, namespacePrefix)
+		logger := c.m.cfg.Logger.With(loggerFields...)
 		if c.m.cfg.TopicLogFieldFunc != nil {
 			logger = logger.With(c.m.cfg.TopicLogFieldFunc(topicName))
 		}
@@ -222,6 +222,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		}
 		for _, response := range updateResp.Sorted() {
 			topicName := strings.TrimPrefix(response.Topic, namespacePrefix)
+			logger := c.m.cfg.Logger.With(loggerFields...)
 			if c.m.cfg.TopicLogFieldFunc != nil {
 				logger = logger.With(c.m.cfg.TopicLogFieldFunc(topicName))
 			}
@@ -264,6 +265,7 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		}
 		for _, response := range alterResp {
 			topicName := strings.TrimPrefix(response.Name, namespacePrefix)
+			logger := c.m.cfg.Logger.With(loggerFields...)
 			if c.m.cfg.TopicLogFieldFunc != nil {
 				logger = logger.With(c.m.cfg.TopicLogFieldFunc(topicName))
 			}


### PR DESCRIPTION
logger should be scoped to the loop/response because the logfieldfunc could set topic-specific fields
