### PR TITLE
ci: use elastic/oblt-actions/google/auth action

### DIFF
--- a/.github/actions/system-test/action.yml
+++ b/.github/actions/system-test/action.yml
@@ -2,11 +2,6 @@ name: system-test
 
 description: Steps to run system test
 
-inputs:
-  workload-identity-provider:
-    description: 'GCP Workload Identity Provider'
-    required: true
-
 runs:
   using: composite
   steps:

--- a/.github/actions/system-test/action.yml
+++ b/.github/actions/system-test/action.yml
@@ -8,6 +8,8 @@ runs:
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.4.6
+      # The permissions for this action are set up
+      # at https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/apm-queue/01-gcp-oidc.tf
     - uses: 'elastic/oblt-actions/google/auth@v1'
     - uses: 'google-github-actions/setup-gcloud@v2'
     - uses: 'google-github-actions/get-gke-credentials@v2'

--- a/.github/actions/system-test/action.yml
+++ b/.github/actions/system-test/action.yml
@@ -13,15 +13,10 @@ runs:
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.4.6
-    - id: gcp-auth
-      uses: 'google-github-actions/auth@v2'
-      with:
-        project_id: 'elastic-observability'
-        workload_identity_provider: '${{ inputs.workload-identity-provider }}'
+    - uses: 'elastic/oblt-actions/google/auth@v1'
     - uses: 'google-github-actions/setup-gcloud@v2'
     - uses: 'google-github-actions/get-gke-credentials@v2'
       with:
-        project_id: ${{ steps.gcp-auth.outputs.project_id }}
         cluster_name: 'autopilot-oblt'
         location: 'us-central1'
     - uses: actions/setup-go@v5

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -23,5 +23,3 @@ jobs:
             github.event.pull_request.head.repo.full_name == github.repository
           )
         uses: ./.github/actions/system-test
-        with:
-          workload-identity-provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'


### PR DESCRIPTION
## Details

This will replace the native `google-github-actions/auth` action with our opinionated `elastic/oblt-actions/google/auth` action.

The opinionated action comes with defaults, which are aligned with how we set up OIDC in a standardized way.
