### PR TITLE
Use WARN for broker connect DeadlineExceeded errs

### DIFF
--- a/kafka/logger_test.go
+++ b/kafka/logger_test.go
@@ -57,10 +57,8 @@ func TestHookLogsFailedDial(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
 		defer cancel()
 		cfg.Dialer = func(context.Context, string, string) (net.Conn, error) {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
+			<-ctx.Done()
+			return nil, ctx.Err()
 		}
 		// Calling newClient triggers the metadata refresh, forcing a connection to the fake cluster
 		// using the broken dialer.


### PR DESCRIPTION
This change updates the logger to use WARN instead of ERROR for broker connect DeadlineExceeded errors. This is because DeadlineExceeded errors since they don't indicate a problem, but we still want to log them as warnings in case they correlate with other events.