### PR TITLE
feat: allow customizing TLS ServerName

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -203,6 +203,18 @@ aws_session_token=IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3JpZ2luX2IQoJb3
 				Logger:  zap.NewNop(),
 			})
 		})
+
+		t.Run("tls_override_server_name", func(t *testing.T) {
+			t.Setenv("KAFKA_TLS_SERVER_NAME", "overriden.server.name")
+			assertValid(t, CommonConfig{
+				Brokers: []string{"broker"},
+				Logger:  zap.NewNop().Named("kafka"),
+				TLS:     &tls.Config{ServerName: "overriden.server.name"},
+			}, CommonConfig{
+				Brokers: []string{"broker"},
+				Logger:  zap.NewNop(),
+			})
+		})
 	})
 
 	t.Run("configfile_from_env", func(t *testing.T) {


### PR DESCRIPTION
### Reason for this PR

In some cases, it is meaningful to set the [`tls.Config.ServerName`](https://cs.opensource.google/go/go/+/refs/tags/go1.24.0:src/crypto/tls/common.go;l=668) field (for example when brokers are replying to clients with their IP).

This PR adds configuration via environment variable to allow customizing the ServerName field.

