### PR TITLE
add none as the default compression codec

### DIFF
--- a/kafka/common_test.go
+++ b/kafka/common_test.go
@@ -378,6 +378,7 @@ func newClusterWithTopics(t testing.TB, partitions int32, topics ...string) (*kg
 		kgo.SeedBrokers(addrs...),
 		// Reduce the max wait time to speed up tests.
 		kgo.FetchMaxWait(100*time.Millisecond),
+		kgo.ProducerBatchCompression(kgo.NoCompression()), // ensures compression.codec = "none"
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes https://github.com/elastic/apm-queue/issues/704

Set the default compression codec to `none` for testing.