### PR TITLE
ignore unknown topic warning

### DIFF
--- a/kafka/common.go
+++ b/kafka/common.go
@@ -146,6 +146,10 @@ type CommonConfig struct {
 	// DisableTelemetry disables the OpenTelemetry hook.
 	DisableTelemetry bool
 
+	// IgnoreUnknownTopicWarning ignores UNKNOWN_TOPIC_OR_PARTITION warnings
+	// when monitoring consumer lag for a deleted topic.
+	DisableUnknownTopicWarning bool
+
 	// TracerProvider allows specifying a custom otel tracer provider.
 	// Defaults to the global one.
 	TracerProvider trace.TracerProvider

--- a/kafka/common.go
+++ b/kafka/common.go
@@ -146,10 +146,6 @@ type CommonConfig struct {
 	// DisableTelemetry disables the OpenTelemetry hook.
 	DisableTelemetry bool
 
-	// IgnoreUnknownTopicWarning ignores UNKNOWN_TOPIC_OR_PARTITION warnings
-	// when monitoring consumer lag for a deleted topic.
-	DisableUnknownTopicWarning bool
-
 	// TracerProvider allows specifying a custom otel tracer provider.
 	// Defaults to the global one.
 	TracerProvider trace.TracerProvider
@@ -184,6 +180,10 @@ type CommonConfig struct {
 	// The lower the value the more frequently new topics will be discovered.
 	// If zero, the default value of 5 minutes is used.
 	MetadataMaxAge time.Duration
+
+	// LogUnknownTopicWarning will log UNKNOWN_TOPIC_OR_PARTITION warnings
+	// when monitoring consumer lag for a deleted topic.
+	LogUnknownTopicWarning bool
 
 	hooks []kgo.Hook
 }

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -277,6 +277,9 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 				}
 				for partition, lag := range partitions {
 					if lag.Err != nil {
+						if lag.Err == kerr.UnknownTopicOrPartition && m.cfg.DisableUnknownTopicWarning {
+							continue
+						}
 						logger.Warn("error getting consumer group lag",
 							zap.String("group", l.Group),
 							zap.String("topic", topic),

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -277,7 +277,7 @@ func (m *Manager) MonitorConsumerLag(topicConsumers []apmqueue.TopicConsumer) (m
 				}
 				for partition, lag := range partitions {
 					if lag.Err != nil {
-						if lag.Err == kerr.UnknownTopicOrPartition && m.cfg.DisableUnknownTopicWarning {
+						if lag.Err == kerr.UnknownTopicOrPartition && !m.cfg.LogUnknownTopicWarning {
 							continue
 						}
 						logger.Warn("error getting consumer group lag",

--- a/kafka/manager_test.go
+++ b/kafka/manager_test.go
@@ -773,16 +773,16 @@ func TestListTopics(t *testing.T) {
 
 func TestUnknownTopicOrPartition(t *testing.T) {
 	testCases := []struct {
-		desc          string
-		ignoreWarning bool
+		desc       string
+		logWarning bool
 	}{
 		{
-			desc:          "log UNKNOWN_TOPIC_OR_PARTITION warning for consumer lag",
-			ignoreWarning: false,
+			desc:       "log UNKNOWN_TOPIC_OR_PARTITION warning for consumer lag",
+			logWarning: true,
 		},
 		{
-			desc:          "ignore UNKNOWN_TOPIC_OR_PARTITION warning for consumer lag",
-			ignoreWarning: true,
+			desc:       "ignore UNKNOWN_TOPIC_OR_PARTITION warning for consumer lag",
+			logWarning: true,
 		},
 	}
 	for _, tc := range testCases {
@@ -793,7 +793,7 @@ func TestUnknownTopicOrPartition(t *testing.T) {
 		cluster, commonConfig := newFakeCluster(t)
 		core, observedLogs := observer.New(zapcore.DebugLevel)
 
-		commonConfig.DisableUnknownTopicWarning = tc.ignoreWarning
+		commonConfig.LogUnknownTopicWarning = tc.logWarning
 		commonConfig.Logger = zap.New(core)
 		commonConfig.MeterProvider = mp
 
@@ -875,9 +875,7 @@ func TestUnknownTopicOrPartition(t *testing.T) {
 		matchingLogs := observedLogs.FilterFieldKey("group")
 		actual := matchingLogs.AllUntimed()
 
-		if tc.ignoreWarning {
-			assert.Empty(t, actual)
-		} else {
+		if tc.logWarning {
 			expected := []observer.LoggedEntry{
 				{
 					Entry: zapcore.Entry{
@@ -896,6 +894,8 @@ func TestUnknownTopicOrPartition(t *testing.T) {
 			}
 			assert.Len(t, actual, 1)
 			assert.Equal(t, expected, actual)
+		} else {
+			assert.Empty(t, actual)
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/elastic/hosted-otel-controller/issues/154

Add a config option to toggle logging the `UNKNOWN_TOPIC_OR_PARTITION` warning when monitoring consumer lag. The default will be `false`, meaning the warning will **not** be logged.