### PR TITLE
Fix indefinitely stuck consumer on fetch DeadlineExceeded

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -367,7 +367,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 				continue
 			}
 
-			return err
+			return fmt.Errorf("consumer fetch error: %w", err)
 		}
 	}
 }


### PR DESCRIPTION
Handle DeadlineExceeded properly without stopping consumer, as these can happen when network is unstable.
