### PR TITLE
kafka: apply topic configs via AlterTopicConfigs after creation

### DIFF
--- a/kafka/topiccreator.go
+++ b/kafka/topiccreator.go
@@ -133,7 +133,8 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 	missingTopics, updatePartitions, existingTopics := c.categorizeTopics(existing, topicNames)
 
 	var updateErrors []error
-	if err := c.createMissingTopics(ctx, span, missingTopics); err != nil {
+	createdTopics, err := c.createMissingTopics(ctx, span, missingTopics)
+	if err != nil {
 		updateErrors = append(updateErrors, err)
 	}
 
@@ -141,7 +142,13 @@ func (c *TopicCreator) CreateTopics(ctx context.Context, topics ...apmqueue.Topi
 		updateErrors = append(updateErrors, err)
 	}
 
-	if err := c.alterTopicConfigs(ctx, span, existingTopics); err != nil {
+	// Apply topic configs to both pre-existing and newly created topics.
+	// Some Kafka-compatible systems (e.g. WarpStream) silently ignore
+	// vendor-specific configs passed in CreateTopics requests, so we
+	// always follow up with an explicit AlterTopicConfigs call to ensure
+	// configs are applied.
+	topicsToAlter := append(existingTopics, createdTopics...)
+	if err := c.alterTopicConfigs(ctx, span, topicsToAlter); err != nil {
 		updateErrors = append(updateErrors, err)
 	}
 
@@ -170,13 +177,18 @@ func (c *TopicCreator) categorizeTopics(
 	return missingTopics, updatePartitions, existingTopics
 }
 
+// createMissingTopics creates topics that do not yet exist and returns the
+// names of topics that are now live — either freshly created or already
+// present (TopicAlreadyExists). Topics that fail with any other error are
+// excluded from the returned slice so callers do not attempt to configure
+// a topic that was never created.
 func (c *TopicCreator) createMissingTopics(
 	ctx context.Context,
 	span trace.Span,
 	missingTopics []string,
-) error {
+) ([]string, error) {
 	if len(missingTopics) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	responses, err := c.m.adminClient.CreateTopics(ctx,
@@ -188,7 +200,7 @@ func (c *TopicCreator) createMissingTopics(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		return fmt.Errorf("failed to create kafka topics: %w", err)
+		return nil, fmt.Errorf("failed to create kafka topics: %w", err)
 	}
 
 	namespacePrefix := c.m.cfg.namespacePrefix()
@@ -202,7 +214,10 @@ func (c *TopicCreator) createMissingTopics(
 		)
 	}
 
-	var updateErrors []error
+	var (
+		liveTopic    = make([]string, 0, len(missingTopics))
+		updateErrors []error
+	)
 	for _, response := range responses.Sorted() {
 		topicName := strings.TrimPrefix(response.Topic, namespacePrefix)
 
@@ -219,6 +234,8 @@ func (c *TopicCreator) createMissingTopics(
 				span.AddEvent("kafka topic already exists", trace.WithAttributes(
 					semconv.MessagingDestinationKey.String(topicName),
 				))
+				// Topic is live — include it so its configs get applied.
+				liveTopic = append(liveTopic, response.Topic)
 			} else {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
@@ -245,13 +262,10 @@ func (c *TopicCreator) createMissingTopics(
 		))
 
 		logger.Info("created kafka topic", zap.String("topic", topicName))
+		liveTopic = append(liveTopic, response.Topic)
 	}
 
-	if len(updateErrors) > 0 {
-		return errors.Join(updateErrors...)
-	}
-
-	return nil
+	return liveTopic, errors.Join(updateErrors...)
 }
 
 func (c *TopicCreator) updateTopicPartitions(

--- a/kafka/topiccreator_test.go
+++ b/kafka/topiccreator_test.go
@@ -234,7 +234,10 @@ func TestCreateTopics(t *testing.T) {
 		{Topic: "name_space-topic0", Count: 123},
 	}, createPartitionsRequest.Topics)
 
-	// Ensure the `cleanup.policy` field for `topic0` is deleted.
+	// Ensure the `cleanup.policy` field is deleted for all topics, and that
+	// AlterTopicConfigs is called for both pre-existing topics (topic0) AND
+	// newly created / already-existing topics (topic1, topic3, topic4).
+	// topic2 failed creation, so it must not appear here.
 	expectedAlter := []kmsg.IncrementalAlterConfigsRequestResource{
 		{
 			ResourceType: kmsg.ConfigResourceTypeTopic,
@@ -246,10 +249,39 @@ func TestCreateTopics(t *testing.T) {
 				},
 			},
 		},
+		{
+			ResourceType: kmsg.ConfigResourceTypeTopic,
+			ResourceName: "name_space-topic1",
+			Configs: []kmsg.IncrementalAlterConfigsRequestResourceConfig{
+				{
+					Name:  "retention.ms",
+					Value: kmsg.StringPtr("123"),
+				},
+			},
+		},
+		{
+			ResourceType: kmsg.ConfigResourceTypeTopic,
+			ResourceName: "name_space-topic3",
+			Configs: []kmsg.IncrementalAlterConfigsRequestResourceConfig{
+				{
+					Name:  "retention.ms",
+					Value: kmsg.StringPtr("123"),
+				},
+			},
+		},
+		{
+			ResourceType: kmsg.ConfigResourceTypeTopic,
+			ResourceName: "name_space-topic4",
+			Configs: []kmsg.IncrementalAlterConfigsRequestResourceConfig{
+				{
+					Name:  "retention.ms",
+					Value: kmsg.StringPtr("123"),
+				},
+			},
+		},
 	}
 
-	// Ensure only the existing topic config is updated since it already exists.
-	assert.Len(t, alterConfigsRequest.Resources, 1)
+	assert.Len(t, alterConfigsRequest.Resources, 4)
 	sortAlteredConfigs(t, expectedAlter)
 	sortAlteredConfigs(t, alterConfigsRequest.Resources)
 	assert.Equal(t, expectedAlter, alterConfigsRequest.Resources)
@@ -325,6 +357,39 @@ func TestCreateTopics(t *testing.T) {
 				"retention.ms":   "123",
 			}),
 			zap.String("topic", "topic0"),
+		},
+	}, {
+		Entry: zapcore.Entry{LoggerName: "kafka", Message: "altered configuration for kafka topic"},
+		Context: []zapcore.Field{
+			zap.String("namespace", "name_space"),
+			zap.Int("partition_count", 123),
+			zap.Any("topic_configs", map[string]string{
+				"cleanup.policy": "compact,delete",
+				"retention.ms":   "123",
+			}),
+			zap.String("topic", "topic1"),
+		},
+	}, {
+		Entry: zapcore.Entry{LoggerName: "kafka", Message: "altered configuration for kafka topic"},
+		Context: []zapcore.Field{
+			zap.String("namespace", "name_space"),
+			zap.Int("partition_count", 123),
+			zap.Any("topic_configs", map[string]string{
+				"cleanup.policy": "compact,delete",
+				"retention.ms":   "123",
+			}),
+			zap.String("topic", "topic3"),
+		},
+	}, {
+		Entry: zapcore.Entry{LoggerName: "kafka", Message: "altered configuration for kafka topic"},
+		Context: []zapcore.Field{
+			zap.String("namespace", "name_space"),
+			zap.Int("partition_count", 123),
+			zap.Any("topic_configs", map[string]string{
+				"cleanup.policy": "compact,delete",
+				"retention.ms":   "123",
+			}),
+			zap.String("topic", "topic4"),
 		},
 	}}, matchingLogs.AllUntimed(), cmpopts.SortSlices(func(a, b observer.LoggedEntry) bool {
 		var ai, bi int
@@ -408,6 +473,11 @@ func sortTopicConfigs(t *testing.T, topics []kmsg.CreateTopicsRequestTopic) {
 
 func sortAlteredConfigs(t *testing.T, topics []kmsg.IncrementalAlterConfigsRequestResource) {
 	t.Helper()
+	// Sort resources by name so the order is deterministic across calls.
+	sort.Slice(topics, func(a, b int) bool {
+		return topics[a].ResourceName < topics[b].ResourceName
+	})
+	// Sort configs within each resource by name.
 	for i := range topics {
 		sort.Slice(topics[i].Configs, func(a, b int) bool {
 			return topics[i].Configs[a].Name < topics[i].Configs[b].Name


### PR DESCRIPTION
## Summary

Some Kafka-compatible systems (e.g. WarpStream) silently ignore vendor-specific configs — such as `warpstream.*` — when they are passed in the `CreateTopics` request. Standard Kafka configs like `retention.ms` work correctly at creation time, but custom configs are only reliably applied via a subsequent `IncrementalAlterConfigs` call.

### Root cause

`CreateTopics` categorises topics into three buckets and processes them separately:

- **missing** → created via `CreateTopics` API (configs passed here, but ignored by WarpStream for vendor-specific keys)
- **existing** → partition count updated via `UpdatePartitions`
- **existing** → configs updated via `AlterTopicConfigs` ✅

Only pre-existing topics went through `AlterTopicConfigs`. Newly created topics never did, so `warpstream.*` configs were never applied on first creation.

### Fix

- `createMissingTopics` now returns the list of topics that are **live** after the call (freshly created + `TopicAlreadyExists`). Topics that fail with a real error are excluded.
- `CreateTopics` merges those into the `alterTopicConfigs` call alongside the pre-existing topics, so `IncrementalAlterConfigs` is always issued for every live topic.

## Testing

- Updated `TestCreateTopics` to assert that `AlterTopicConfigs` is called for all live topics (topic0 pre-existing + topic1/3/4 from the creation response), not just the pre-existing one.
- Fixed `sortAlteredConfigs` to also sort resources by `ResourceName` for deterministic ordering.

> **Note:** This PR is a draft pending confirmation from the WarpStream/Confluent team that ignoring `warpstream.*` configs in `CreateTopics` is expected behaviour. See repro gist: https://gist.github.com/zmoog/e54f2c8e7f02e54cef5238ed04a244b2

🤖 Generated with [Claude Code](https://claude.com/claude-code)